### PR TITLE
Add install target and integration tests

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -1,4 +1,6 @@
 # Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024 The Khronos Group Inc.
+# Copyright (c) 2024 RasterGrid Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,13 +47,16 @@ jobs:
             - uses: actions/checkout@v3
 
             - name: Configure VulkanSC PCUtils
-              run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.config}}
+              run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.config}} -D BUILD_TESTS=ON
               env:
                 CC: ${{matrix.cc}}
                 CXX: ${{matrix.cxx}}
 
             - name: Build VulkanSC PCUtils
               run: cmake --build build
+
+            - name: Run CTest
+              run: ctest --output-on-failure
 
             - name: Run regression tests
               working-directory: ./build
@@ -72,10 +77,13 @@ jobs:
             - uses: actions/checkout@v3
 
             - name: Configure VulkanSC PCUtils
-              run: cmake -S. -Bbuild -A${{matrix.arch}}
+              run: cmake -S. -Bbuild -A${{matrix.arch}} -D BUILD_TESTS=ON
 
             - name: Build VulkanSC PCUtils
               run: cmake --build build  --config ${{matrix.config}}
+
+            - name: Run CTest
+              run: ctest --output-on-failure
 
 #            - name: Run regression tests
 #              working-directory: ./build
@@ -95,10 +103,13 @@ jobs:
             - uses: actions/checkout@v3
 
             - name: Configure VulkanSC PCUtils
-              run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.config}}
+              run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.config}} -D BUILD_TESTS=ON
 
             - name: Build VulkanSC PCUtils
               run: cmake --build build
+
+            - name: Run CTest
+              run: ctest --output-on-failure
 
             - name: Run regression tests
               working-directory: ./build

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ ptest32
 pcinfo
 *.dSYM/*
 *.swp
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
 # Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024 The Khronos Group Inc.
+# Copyright (c) 2024 RasterGrid Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +28,70 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_COMPILE_FLAGS}")
 endif()
 
+add_library(VulkanSC-pcutil INTERFACE)
+add_library(VulkanSC::pcutil ALIAS VulkanSC-pcutil)
+
+target_include_directories(VulkanSC-pcutil INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+# Create vulkansc-pcutil-targets.cmake
+set_target_properties(VulkanSC-pcutil PROPERTIES EXPORT_NAME "pcutil")
+install(
+    TARGETS VulkanSC-pcutil
+    EXPORT vulkansc-pcutil-targets
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(
+    EXPORT vulkansc-pcutil-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/VulkanSC-pcutil
+    NAMESPACE VulkanSC::
+)
+
+# Create vulkansc-pcutil-config.cmake
+set(PCUTIL_EXPORT_TARGETS ${CMAKE_INSTALL_LIBDIR}/cmake/VulkanSC-pcutil/vulkansc-pcutil-targets.cmake)
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/vulkansc-pcutil-config.cmake.in" [=[
+    include(CMakeFindDependencyMacro)
+    # NOTE: Because VulkanHeaders is a PUBLIC dependency it needs to be found prior to VulkanSC-pcutil
+    find_dependency(VulkanHeaders REQUIRED)
+
+    @PACKAGE_INIT@
+
+    include(@PACKAGE_PCUTIL_EXPORT_TARGETS@)
+]=])
+
+configure_package_config_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/vulkansc-pcutil-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/vulkansc-pcutil-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/VulkanSC-pcutil
+    PATH_VARS PCUTIL_EXPORT_TARGETS
+    NO_SET_AND_CHECK_MACRO
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/vulkansc-pcutil-config.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/VulkanSC-pcutil
+)
+
+install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/pcreader.hpp ${CMAKE_CURRENT_SOURCE_DIR}/pcwriter.hpp
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+option(BUILD_TESTS "Build tests")
+if (BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
+
 add_executable(pcinfo pcinfo.cpp)
+
+target_link_libraries(pcinfo PRIVATE VulkanSC-pcutil)
 
 target_include_directories(pcinfo PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/fake/)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,30 @@
+# ~~~
+# Copyright (c) 2024 The Khronos Group Inc.
+# Copyright (c) 2024 RasterGrid Kft.
+#
+# SPDX-License-Identifier: Apache-2.0
+# ~~~
+
+# Test install
+set(test_install_dir "${CMAKE_CURRENT_BINARY_DIR}/install")
+add_test(NAME integration.install
+    COMMAND ${CMAKE_COMMAND} --install ${PROJECT_BINARY_DIR} --prefix ${test_install_dir} --config $<CONFIG>
+)
+
+# Test add_subdirectory support
+add_test(NAME integration.add_subdirectory
+    COMMAND ${CMAKE_CTEST_COMMAND}
+        --build-and-test ${CMAKE_CURRENT_LIST_DIR}/integration ${CMAKE_CURRENT_BINARY_DIR}/add_subdirectory
+        --build-generator ${CMAKE_GENERATOR}
+        --build-options -DFIND_PACKAGE_TESTING=OFF -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+)
+
+# Test find_package support
+add_test(NAME integration.find_package
+    COMMAND ${CMAKE_CTEST_COMMAND}
+        --build-and-test ${CMAKE_CURRENT_LIST_DIR}/integration ${CMAKE_CURRENT_BINARY_DIR}/find_package
+        --build-generator ${CMAKE_GENERATOR}
+        --build-options -DFIND_PACKAGE_TESTING=ON "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH};${test_install_dir}"
+)
+
+set_tests_properties(integration.find_package PROPERTIES DEPENDS integration.install)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,0 +1,27 @@
+# ~~~
+# Copyright (c) 2024 The Khronos Group Inc.
+# Copyright (c) 2024 RasterGrid Kft.
+#
+# SPDX-License-Identifier: Apache-2.0
+# ~~~
+
+cmake_minimum_required(VERSION 3.10.2)
+
+project(integration LANGUAGES CXX)
+
+# We need the fake vulkan_sc_core.hpp on the include path, unfortunately
+# without actually including the VulkanSC-Headers package
+include_directories(${PROJECT_SOURCE_DIR}/../../fake)
+
+if(FIND_PACKAGE_TESTING)
+    find_package(VulkanSC-pcutil REQUIRED CONFIG)
+else()
+    add_subdirectory(${PROJECT_SOURCE_DIR}/../../ ${PROJECT_BINARY_DIR}/subdir)
+endif()
+
+if(NOT TARGET VulkanSC::pcutil)
+    message(FATAL_ERROR "VulkanSC::pcutil target not defined!")
+endif()
+
+add_executable(test test.cpp)
+target_link_libraries(test PRIVATE VulkanSC::pcutil)

--- a/tests/integration/test.cpp
+++ b/tests/integration/test.cpp
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 The Khronos Group Inc.
+ * Copyright (c) 2024 RasterGrid Kft.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <pcreader.hpp>
+#include <pcwriter.hpp>
+
+int main() {
+    return 0;
+}


### PR DESCRIPTION
This solution is far from perfect, as the project lacks a proper directory structure, but at least allows for using the repository as a dependency in ecosystem components.

If preferred, we can rework the directory structure too.