### PR TITLE
Struct generator utilities

### DIFF
--- a/library/pcjson/generated/vksc_pipeline_json_gen.hpp
+++ b/library/pcjson/generated/vksc_pipeline_json_gen.hpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <sstream>
 #include <algorithm>
+#include <bitset>
 #include <math.h>
 
 #include "vksc_pipeline_json_base.hpp"
@@ -3059,10 +3060,13 @@ class GeneratorBase : protected Base {
             return 0;
         }
         std::stringstream strm;
-        std::array<VkCullModeFlagBits, 1> multi_bit_flags{{VkCullModeFlagBits::VK_CULL_MODE_FRONT_AND_BACK}};
+        std::array<std::bitset<32>, 1> multi_bitsets{{VkCullModeFlagBits::VK_CULL_MODE_FRONT_AND_BACK}};
+        std::sort(multi_bitsets.begin(), multi_bitsets.end(),
+                  [](const auto& lhs, const auto& rhs) { return lhs.count() > rhs.count(); });
         std::vector<VkCullModeFlagBits> matched_multi_bit_flags;
-        for (auto multi_bit_flag : multi_bit_flags) {
-            if (v == multi_bit_flag) {
+        for (const auto& multi_bitset : multi_bitsets) {
+            VkCullModeFlagBits multi_bit_flag = static_cast<VkCullModeFlagBits>(multi_bitset.to_ulong());
+            if ((v & multi_bit_flag) == multi_bit_flag) {
                 matched_multi_bit_flags.push_back(multi_bit_flag);
                 if (strm.rdbuf()->in_avail() > 0) {
                     strm << " | ";
@@ -3248,11 +3252,14 @@ class GeneratorBase : protected Base {
             return 0;
         }
         std::stringstream strm;
-        std::array<VkShaderStageFlagBits, 2> multi_bit_flags{
+        std::array<std::bitset<32>, 2> multi_bitsets{
             {VkShaderStageFlagBits::VK_SHADER_STAGE_ALL_GRAPHICS, VkShaderStageFlagBits::VK_SHADER_STAGE_ALL}};
+        std::sort(multi_bitsets.begin(), multi_bitsets.end(),
+                  [](const auto& lhs, const auto& rhs) { return lhs.count() > rhs.count(); });
         std::vector<VkShaderStageFlagBits> matched_multi_bit_flags;
-        for (auto multi_bit_flag : multi_bit_flags) {
-            if (v == multi_bit_flag) {
+        for (const auto& multi_bitset : multi_bitsets) {
+            VkShaderStageFlagBits multi_bit_flag = static_cast<VkShaderStageFlagBits>(multi_bitset.to_ulong());
+            if ((v & multi_bit_flag) == multi_bit_flag) {
                 matched_multi_bit_flags.push_back(multi_bit_flag);
                 if (strm.rdbuf()->in_avail() > 0) {
                     strm << " | ";

--- a/library/pcjson/generated/vksc_pipeline_json_gen.hpp
+++ b/library/pcjson/generated/vksc_pipeline_json_gen.hpp
@@ -3072,6 +3072,7 @@ class GeneratorBase : protected Base {
                     strm << " | ";
                 }
                 strm << gen_VkCullModeFlagBits_c_str(static_cast<VkCullModeFlagBits>(multi_bit_flag));
+                break;
             }
         }
         auto isnt_part_of_any_matched_multi_bit_flags = [&](const auto bit) {
@@ -3265,6 +3266,7 @@ class GeneratorBase : protected Base {
                     strm << " | ";
                 }
                 strm << gen_VkShaderStageFlagBits_c_str(static_cast<VkShaderStageFlagBits>(multi_bit_flag));
+                break;
             }
         }
         auto isnt_part_of_any_matched_multi_bit_flags = [&](const auto bit) {

--- a/library/pcjson/vksc_pipeline_json_gen.cpp
+++ b/library/pcjson/vksc_pipeline_json_gen.cpp
@@ -630,7 +630,9 @@ class Generator : private GeneratorBase {
                     Error() << "Ouf of range " << object_set_name << " id (" << name_id << ") during resolving names";
                 }
             }
-            json_array.copy(new_array);
+            if (new_array.size() > 0) {
+                json_array.copy(new_array);
+            }
         };
 
         if (state.ppDescriptorSetLayoutNames != nullptr) {

--- a/scripts/generators/json_gen_generator.py
+++ b/scripts/generators/json_gen_generator.py
@@ -287,6 +287,7 @@ class JsonGenGenerator(BaseGenerator):
                                 strm << " | ";
                             }}
                             strm << gen_{flags.bitmaskName}_c_str(static_cast<{flags.bitmaskName}>(multi_bit_flag));
+                            break;
                         }}
                     }}
                     auto isnt_part_of_any_matched_multi_bit_flags = [&](const auto bit){{

--- a/scripts/generators/json_gen_generator.py
+++ b/scripts/generators/json_gen_generator.py
@@ -37,6 +37,7 @@ class JsonGenGenerator(BaseGenerator):
             #include <string>
             #include <sstream>
             #include <algorithm>
+            #include <bitset>
             #include <math.h>
 
             #include "vksc_pipeline_json_base.hpp"
@@ -273,12 +274,14 @@ class JsonGenGenerator(BaseGenerator):
             multi_bit_flags = [flag for flag in self.vk.bitmasks[flags.bitmaskName].flags if flag.multiBit]
             if multi_bit_flags:
                 out.append(f'''
-                    std::array<{flags.bitmaskName}, {len(multi_bit_flags)}> multi_bit_flags{{{{
+                    std::array<std::bitset<32>, {len(multi_bit_flags)}> multi_bitsets{{{{
                         {','.join([f'{flags.bitmaskName}::{f.name}' for f in multi_bit_flags])}
                     }}}};
+                    std::sort(multi_bitsets.begin(), multi_bitsets.end(), [](const auto& lhs, const auto& rhs){{ return lhs.count() > rhs.count(); }});
                     std::vector<{flags.bitmaskName}> matched_multi_bit_flags;
-                    for (auto multi_bit_flag : multi_bit_flags) {{
-                        if (v == multi_bit_flag) {{
+                    for (const auto& multi_bitset : multi_bitsets) {{
+                        {flags.bitmaskName} multi_bit_flag = static_cast<{flags.bitmaskName}>(multi_bitset.to_ulong());
+                        if ((v & multi_bit_flag) == multi_bit_flag) {{
                             matched_multi_bit_flags.push_back(multi_bit_flag);
                             if (strm.rdbuf()->in_avail() > 0) {{
                                 strm << " | ";

--- a/tests/json_struct_helpers.h
+++ b/tests/json_struct_helpers.h
@@ -505,36 +505,6 @@ std::pair<vku::safe_VkPipelineLayoutCreateInfo, std::string> getVkPipelineLayout
     return {&ci, json};
 }
 
-std::pair<vku::safe_VkPipelineShaderStageRequiredSubgroupSizeCreateInfo, std::string>
-getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo(uint32_t seed = 0) {
-    using namespace std::string_literals;
-
-    VkPipelineShaderStageRequiredSubgroupSizeCreateInfo ci = vku::InitStructHelper();
-    std::string json{};
-
-    switch (seed % 3) {
-        case 0:
-            ci.requiredSubgroupSize = 32;
-            break;
-        case 1:
-            ci.requiredSubgroupSize = 64;
-            break;
-        case 2:
-            ci.requiredSubgroupSize = 256;
-            break;
-    }
-
-    json = R"({
-        "sType": "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO",
-            "pNext": "NULL",
-            "requiredSubgroupSize": )"s +
-           std::to_string(ci.requiredSubgroupSize) + R"(
-        })";
-
-    return {&ci, json};
-}
-
-template <typename... InStructure>
 std::pair<vku::safe_VkComputePipelineCreateInfo, std::string> getVkComputePipelineCreateInfo(uint32_t seed = 0) {
     using namespace std::string_literals;
 
@@ -1050,6 +1020,8 @@ std::pair<vku::safe_VkShaderModuleCreateInfo, std::string> getVkShaderModuleCrea
     return {&ci, json};
 }
 
+// TODO: Uncomment all code once safe struct issue is resolved.
+// see: https://github.com/KhronosGroup/Vulkan-Utility-Libraries/issues/343
 std::pair<vku::safe_VkDeviceObjectReservationCreateInfo, std::string> getVkDeviceObjectReservationCreateInfo(uint32_t seed = 0) {
     VkDeviceObjectReservationCreateInfo ci = vku::InitStructHelper();
     std::string json{};
@@ -1057,22 +1029,39 @@ std::pair<vku::safe_VkDeviceObjectReservationCreateInfo, std::string> getVkDevic
     std::vector<uint8_t> initialData{};
     std::vector<VkPipelineCacheCreateInfo> pipelineCacheCreateInfos{};
     std::vector<VkPipelinePoolSize> pipelinePoolSizes{};
+    std::string pPipelineCacheCreateInfos_str = R"("NULL")", pPipelinePoolSizes_str = R"("NULL")";
 
     switch (seed % 2) {
         default:
-            initialData = {0b01101001, 0b10110111, 0b00011101};
-            pipelineCacheCreateInfos.push_back(vku::InitStructHelper());
-            pipelineCacheCreateInfos.back().flags =
-                VK_PIPELINE_CACHE_CREATE_READ_ONLY_BIT | VK_PIPELINE_CACHE_CREATE_USE_APPLICATION_STORAGE_BIT;
-            pipelineCacheCreateInfos.back().initialDataSize = static_cast<uint32_t>(initialData.size());
-            pipelineCacheCreateInfos.back().pInitialData = initialData.data();
-
+            // initialData = {0b01101001, 0b10110111, 0b00011101};
+            // pipelineCacheCreateInfos.push_back(vku::InitStructHelper());
+            // pipelineCacheCreateInfos.back().flags =
+            //     VK_PIPELINE_CACHE_CREATE_READ_ONLY_BIT | VK_PIPELINE_CACHE_CREATE_USE_APPLICATION_STORAGE_BIT;
+            // pipelineCacheCreateInfos.back().initialDataSize = static_cast<uint32_t>(initialData.size());
+            // pipelineCacheCreateInfos.back().pInitialData = initialData.data();
+            // pPipelineCacheCreateInfos_str = R"([
+            //     {
+            //         "sType": "VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO",
+            //         "pNext": "NULL",
+            //         "flags": "VK_PIPELINE_CACHE_CREATE_READ_ONLY_BIT | VK_PIPELINE_CACHE_CREATE_USE_APPLICATION_STORAGE_BIT",
+            //         "initialDataSize": 3,
+            //         "pInitialData": "abcd"
+            //     }
+            //])";
             ci.pipelineCacheCreateInfoCount = static_cast<uint32_t>(pipelineCacheCreateInfos.size());
             ci.pPipelineCacheCreateInfos = pipelineCacheCreateInfos.data();
 
-            pipelinePoolSizes.push_back(vku::InitStructHelper());
-            pipelinePoolSizes.back().poolEntryCount = 1;
-            pipelinePoolSizes.back().poolEntrySize = 1048576;
+            // pipelinePoolSizes.push_back(vku::InitStructHelper());
+            // pipelinePoolSizes.back().poolEntryCount = 1;
+            // pipelinePoolSizes.back().poolEntrySize = 1048576;
+            // pPipelinePoolSizes_str = R"([
+            //     {
+            //         "sType": "VK_STRUCTURE_TYPE_PIPELINE_POOL_SIZE",
+            //         "pNext": "NULL",
+            //         "poolEntryCount": 1,
+            //         "poolEntrySize": 1048576
+            //     }
+            //])";
             ci.pipelinePoolSizeCount = static_cast<uint32_t>(pipelinePoolSizes.size());
             ci.pPipelinePoolSizes = pipelinePoolSizes.data();
 
@@ -1113,28 +1102,17 @@ std::pair<vku::safe_VkDeviceObjectReservationCreateInfo, std::string> getVkDevic
             ci.maxPipelineStatisticsQueriesPerPool = 0;
             ci.maxTimestampQueriesPerPool = 0;
             ci.maxImmutableSamplersPerDescriptorSetLayout = 0;
-            json = R"(json = {R"({
+            json = R"({
         "sType" : "VK_STRUCTURE_TYPE_DEVICE_OBJECT_RESERVATION_CREATE_INFO",
         "pNext": "NULL",
-        "pipelineCacheCreateInfoCount": 1,
-        "pPipelineCacheCreateInfos": [
-            {
-                "sType": "VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO",
-                "pNext": "NULL",
-                "flags": "VK_PIPELINE_CACHE_CREATE_READ_ONLY_BIT | VK_PIPELINE_CACHE_CREATE_USE_APPLICATION_STORAGE_BIT",
-                "initialDataSize": 3,
-                "pInitialData": "abcd"
-            }
-        ],
-        "pipelinePoolSizeCount": 1,
-        "pPipelinePoolSizes": [
-            {
-                "sType": "VK_STRUCTURE_TYPE_PIPELINE_POOL_SIZE",
-                "pNext": "NULL",
-                "poolEntryCount": 1,
-                "poolEntrySize": 1048576
-            }
-        ],
+        "pipelineCacheCreateInfoCount": )" +
+                   std::to_string(pipelineCacheCreateInfos.size()) + R"(,
+        "pPipelineCacheCreateInfos": )" +
+                   pPipelineCacheCreateInfos_str + R"(,
+        "pipelinePoolSizeCount": )" +
+                   std::to_string(pipelinePoolSizes.size()) + R"(,
+        "pPipelinePoolSizes": )" +
+                   pPipelinePoolSizes_str + R"(,
         "semaphoreRequestCount": 0,
         "commandBufferRequestCount": 1,
         "fenceRequestCount": 1,
@@ -1195,441 +1173,6 @@ std::pair<vku::safe_VkPipelineOfflineCreateInfo, std::string> getVkPipelineOffli
             "pipelineIdentifier": [85, 43, 255, 24, 155, 64, 62, 24, 0, 0, 0, 0, 0, 0, 0, 0],
             "matchControl": "VK_PIPELINE_MATCH_CONTROL_APPLICATION_UUID_EXACT_MATCH",
             "poolEntrySize": 1048576
-        })";
-            break;
-    }
-
-    return {&ci, json};
-}
-
-template <typename... InStructure>
-std::pair<vku::safe_VkPipelineVertexInputStateCreateInfo, std::string> getVkPipelineVertexInputStateCreateInfo(
-    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
-    using namespace std::string_literals;
-
-    VkPipelineVertexInputStateCreateInfo ci = vku::InitStructHelper();
-    std::string json{};
-
-    switch (seed % 2) {
-        default:
-            VkVertexInputBindingDescription vertexBindingDescriptions[1] = {{0, 32, VK_VERTEX_INPUT_RATE_VERTEX}};
-            VkVertexInputAttributeDescription vertexAttributeDescriptions[2] = {{0, 0, VK_FORMAT_R32G32B32A32_SFLOAT, 0},
-                                                                                {1, 0, VK_FORMAT_R32G32B32A32_SFLOAT, 16}};
-            ci.vertexBindingDescriptionCount = 1;
-            ci.pVertexBindingDescriptions = vertexBindingDescriptions;
-            ci.vertexAttributeDescriptionCount = 2;
-            ci.pVertexAttributeDescriptions = vertexAttributeDescriptions;
-            json = R"({
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO",
-            "pNext":"NULL",
-            "flags" : 0,
-            "vertexBindingDescriptionCount" : 1,
-            "pVertexBindingDescriptions": [
-                {
-                    "binding" : 0,
-                    "stride" : 32,
-                    "inputRate" : "VK_VERTEX_INPUT_RATE_VERTEX"
-                }
-            ],
-            "vertexAttributeDescriptionCount" : 2,
-            "pVertexAttributeDescriptions": [
-                {
-                    "location" : 0,
-                    "binding" : 0,
-                    "format" : "VK_FORMAT_R32G32B32A32_SFLOAT",
-                    "offset" : 0
-                },
-                {
-                    "location" : 1,
-                    "binding" : 0,
-                    "format" : "VK_FORMAT_R32G32B32A32_SFLOAT",
-                    "offset" : 16
-                }
-            ]
-        })";
-            break;
-    }
-
-    ChainPNext(ci, json, pNext);
-
-    return {&ci, json};
-}
-
-template <typename... InStructure>
-std::pair<vku::safe_VkPipelineInputAssemblyStateCreateInfo, std::string> getVkPipelineInputAssemblyStateCreateInfo(
-    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
-    using namespace std::string_literals;
-
-    VkPipelineInputAssemblyStateCreateInfo ci = vku::InitStructHelper();
-    std::string json{};
-
-    switch (seed % 2) {
-        default:
-            ci.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
-            ci.primitiveRestartEnable = VK_FALSE;
-            json = R"({
-            "sType": "VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO",
-            "pNext": "NULL",
-            "flags": 0,
-            "topology": "VK_PRIMITIVE_TOPOLOGY_PATCH_LIST",
-            "primitiveRestartEnable": "VK_FALSE"
-        })";
-            break;
-    }
-
-    ChainPNext(ci, json, pNext);
-
-    return {&ci, json};
-}
-
-template <typename... InStructure>
-std::pair<vku::safe_VkPipelineTessellationStateCreateInfo, std::string> getVkPipelineTessellationStateCreateInfo(
-    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
-    using namespace std::string_literals;
-
-    VkPipelineTessellationStateCreateInfo ci = vku::InitStructHelper();
-    std::string json{};
-
-    switch (seed % 2) {
-        default:
-            ci.patchControlPoints = 4;
-            json = R"({
-            "sType": "VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO",
-            "pNext": "NULL",
-            "flags": 0,
-            "patchControlPoints": 4
-        })";
-            break;
-    }
-
-    ChainPNext(ci, json, pNext);
-
-    return {&ci, json};
-}
-
-template <typename... InStructure>
-std::pair<vku::safe_VkPipelineViewportStateCreateInfo, std::string> getVkPipelineViewportStateCreateInfo(
-    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
-    using namespace std::string_literals;
-
-    VkPipelineViewportStateCreateInfo ci = vku::InitStructHelper();
-    std::string json{};
-
-    switch (seed % 2) {
-        default:
-            VkViewport viewports[1] = {{0.f, 0.f, 51.f, 51.f, 0.f, 1.f}};
-            VkRect2D scissors[1] = {{VkOffset2D{0, 0}, VkExtent2D{51, 51}}};
-            ci.viewportCount = 1;
-            ci.pViewports = viewports;
-            ci.scissorCount = 1;
-            ci.pScissors = scissors;
-            json = R"({
-            "sType": "VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO",
-            "pNext": "NULL",
-            "flags": 0,
-            "viewportCount": 1,
-            "pViewports":
-            [
-                {
-                    "x": 0.0,
-                    "y": 0.0,
-                    "width": 51.0,
-                    "height": 51.0,
-                    "minDepth": 0.0,
-                    "maxDepth": 1.0
-                }
-            ],
-            "scissorCount": 1,
-            "pScissors":
-            [
-                {
-                    "offset":
-                    {
-                        "x": 0,
-                        "y": 0
-                    },
-                    "extent":
-                    {
-                        "width": 51,
-                        "height": 51
-                    }
-                }
-            ]
-        })";
-            break;
-    }
-
-    ChainPNext(ci, json, pNext);
-
-    return {vku::safe_VkPipelineViewportStateCreateInfo{&ci, false, false}, json};
-}
-
-template <typename... InStructure>
-std::pair<vku::safe_VkPipelineRasterizationStateCreateInfo, std::string> getVkPipelineRasterizationStateCreateInfo(
-    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
-    using namespace std::string_literals;
-
-    VkPipelineRasterizationStateCreateInfo ci = vku::InitStructHelper();
-    std::string json{};
-
-    switch (seed % 2) {
-        default:
-            ci.depthClampEnable = VK_FALSE;
-            ci.rasterizerDiscardEnable = VK_FALSE;
-            ci.polygonMode = VK_POLYGON_MODE_FILL;
-            ci.cullMode = 0;
-            ci.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
-            ci.depthBiasEnable = VK_FALSE;
-            ci.depthBiasConstantFactor = 0.f;
-            ci.depthBiasClamp = 0.f;
-            ci.depthBiasSlopeFactor = 0.f;
-            ci.lineWidth = 1.f;
-            json = R"({
-            "sType": "VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO",
-            "pNext": "NULL",
-            "flags": 0,
-            "depthClampEnable": "VK_FALSE",
-            "rasterizerDiscardEnable": "VK_FALSE",
-            "polygonMode": "VK_POLYGON_MODE_FILL",
-            "cullMode": 0,
-            "frontFace": "VK_FRONT_FACE_COUNTER_CLOCKWISE",
-            "depthBiasEnable": "VK_FALSE",
-            "depthBiasConstantFactor": 0.0,
-            "depthBiasClamp": 0.0,
-            "depthBiasSlopeFactor": 0.0,
-            "lineWidth": 1.0
-        })";
-            break;
-    }
-
-    ChainPNext(ci, json, pNext);
-
-    return {&ci, json};
-}
-
-template <typename... InStructure>
-std::pair<vku::safe_VkPipelineMultisampleStateCreateInfo, std::string> getVkPipelineMultisampleStateCreateInfo(
-    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
-    using namespace std::string_literals;
-
-    VkPipelineMultisampleStateCreateInfo ci = vku::InitStructHelper();
-    std::string json{};
-
-    switch (seed % 2) {
-        default:
-            ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
-            ci.sampleShadingEnable = VK_FALSE;
-            ci.minSampleShading = 1.f;
-            ci.pSampleMask = nullptr;
-            ci.alphaToCoverageEnable = VK_FALSE;
-            ci.alphaToOneEnable = VK_FALSE;
-            json = R"({
-            "sType": "VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO",
-            "pNext": "NULL",
-            "flags": 0,
-            "rasterizationSamples": "VK_SAMPLE_COUNT_1_BIT",
-            "sampleShadingEnable": "VK_FALSE",
-            "minSampleShading": 1.0,
-            "pSampleMask": "NULL",
-            "alphaToCoverageEnable": "VK_FALSE",
-            "alphaToOneEnable": "VK_FALSE"
-        })";
-            break;
-    }
-
-    ChainPNext(ci, json, pNext);
-
-    return {&ci, json};
-}
-
-template <typename... InStructure>
-std::pair<vku::safe_VkPipelineDepthStencilStateCreateInfo, std::string> getVkPipelineDepthStencilStateCreateInfo(
-    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
-    using namespace std::string_literals;
-
-    VkPipelineDepthStencilStateCreateInfo ci = vku::InitStructHelper();
-    std::string json{};
-
-    switch (seed % 2) {
-        default:
-            ci.depthTestEnable = VK_TRUE;
-            ci.depthWriteEnable = VK_TRUE;
-            ci.depthCompareOp = VK_COMPARE_OP_LESS_OR_EQUAL;
-            ci.depthBoundsTestEnable = VK_FALSE;
-            ci.stencilTestEnable = VK_FALSE;
-            ci.front.failOp = VK_STENCIL_OP_INVERT;
-            ci.front.passOp = VK_STENCIL_OP_KEEP;
-            ci.front.depthFailOp = VK_STENCIL_OP_ZERO;
-            ci.front.compareOp = VK_COMPARE_OP_NEVER;
-            ci.front.compareMask = 0;
-            ci.front.writeMask = 0;
-            ci.front.reference = 0;
-            ci.back.failOp = VK_STENCIL_OP_INVERT;
-            ci.back.passOp = VK_STENCIL_OP_KEEP;
-            ci.back.depthFailOp = VK_STENCIL_OP_ZERO;
-            ci.back.compareOp = VK_COMPARE_OP_NEVER;
-            ci.back.compareMask = 0;
-            ci.back.writeMask = 0;
-            ci.back.reference = 0;
-            ci.minDepthBounds = 0.f;
-            ci.maxDepthBounds = 1.f;
-            json = R"({
-            "sType": "VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO",
-            "pNext": "NULL",
-            "flags": 0,
-            "depthTestEnable": "VK_TRUE",
-            "depthWriteEnable": "VK_TRUE",
-            "depthCompareOp": "VK_COMPARE_OP_LESS_OR_EQUAL",
-            "depthBoundsTestEnable": "VK_FALSE",
-            "stencilTestEnable": "VK_FALSE",
-            "front":
-            {
-                "failOp": "VK_STENCIL_OP_INVERT",
-                "passOp": "VK_STENCIL_OP_KEEP",
-                "depthFailOp": "VK_STENCIL_OP_ZERO",
-                "compareOp": "VK_COMPARE_OP_NEVER",
-                "compareMask": 0,
-                "writeMask": 0,
-                "reference": 0
-            },
-            "back":
-            {
-                "failOp": "VK_STENCIL_OP_INVERT",
-                "passOp": "VK_STENCIL_OP_KEEP",
-                "depthFailOp": "VK_STENCIL_OP_ZERO",
-                "compareOp": "VK_COMPARE_OP_NEVER",
-                "compareMask": 0,
-                "writeMask": 0,
-                "reference": 0
-            },
-            "minDepthBounds": 0.0,
-            "maxDepthBounds": 1.0
-        })";
-            break;
-    }
-
-    ChainPNext(ci, json, pNext);
-
-    return {&ci, json};
-}
-
-template <typename... InStructure>
-std::pair<vku::safe_VkPipelineColorBlendStateCreateInfo, std::string> getVkPipelineColorBlendStateCreateInfo(
-    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
-    using namespace std::string_literals;
-
-    VkPipelineColorBlendStateCreateInfo ci = vku::InitStructHelper();
-    std::string json{};
-
-    switch (seed % 2) {
-        default:
-            VkPipelineColorBlendAttachmentState attachments[1] = {
-                {VK_FALSE, VK_BLEND_FACTOR_ZERO, VK_BLEND_FACTOR_ZERO, VK_BLEND_OP_ADD, VK_BLEND_FACTOR_ZERO, VK_BLEND_FACTOR_ZERO,
-                 VK_BLEND_OP_ADD,
-                 VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT}};
-            ci.logicOpEnable = VK_FALSE;
-            ci.logicOp = VK_LOGIC_OP_CLEAR;
-            ci.attachmentCount = 1;
-            ci.pAttachments = attachments;
-            ci.blendConstants[0] = 0.f;
-            ci.blendConstants[1] = 0.f;
-            ci.blendConstants[2] = 0.f;
-            ci.blendConstants[3] = 0.f;
-            json = R"({
-            "sType": "VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO",
-            "pNext": "NULL",
-            "flags": 0,
-            "logicOpEnable": "VK_FALSE",
-            "logicOp": "VK_LOGIC_OP_CLEAR",
-            "attachmentCount": 1,
-            "pAttachments":
-            [
-                {
-                    "blendEnable": "VK_FALSE",
-                    "srcColorBlendFactor": "VK_BLEND_FACTOR_ZERO",
-                    "dstColorBlendFactor": "VK_BLEND_FACTOR_ZERO",
-                    "colorBlendOp": "VK_BLEND_OP_ADD",
-                    "srcAlphaBlendFactor": "VK_BLEND_FACTOR_ZERO",
-                    "dstAlphaBlendFactor": "VK_BLEND_FACTOR_ZERO",
-                    "alphaBlendOp": "VK_BLEND_OP_ADD",
-                    "colorWriteMask": "VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT"
-                }
-            ],
-            "blendConstants": [0.0, 0.0, 0.0, 0.0]
-        })";
-            break;
-    }
-
-    ChainPNext(ci, json, pNext);
-
-    return {&ci, json};
-}
-
-template <typename... InStructure>
-std::pair<vku::safe_VkPipelineDynamicStateCreateInfo, std::string> getVkPipelineDynamicStateCreateInfo(
-    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
-    using namespace std::string_literals;
-
-    VkPipelineDynamicStateCreateInfo ci = vku::InitStructHelper();
-    std::string json{};
-
-    switch (seed % 2) {
-        default:
-            VkDynamicState dynamicStates[1] = {VK_DYNAMIC_STATE_LINE_WIDTH};
-            ci.dynamicStateCount = 1;
-            ci.pDynamicStates = dynamicStates;
-            json = R"({
-            "sType": "VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO",
-            "pNext": "NULL",
-            "flags": 0,
-            "dynamicStateCount": 1,
-            "pDynamicStates": ["VK_DYNAMIC_STATE_LINE_WIDTH"]
-        })";
-            break;
-    }
-
-    ChainPNext(ci, json, pNext);
-
-    return {&ci, json};
-}
-
-std::pair<vku::safe_VkPipelineDiscardRectangleStateCreateInfoEXT, std::string> getVkPipelineDiscardRectangleStateCreateInfoEXT(
-    uint32_t seed = 0) {
-    using namespace std::string_literals;
-
-    VkPipelineDiscardRectangleStateCreateInfoEXT ci = vku::InitStructHelper();
-    std::string json{};
-
-    ci.sType = VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT;
-    ci.pNext = nullptr;
-    ci.flags = 0;
-    VkRect2D discardRectangles{};
-    switch (seed % 2) {
-        default:
-            discardRectangles = {VkOffset2D{0, 0}, VkExtent2D{51, 51}};
-            ci.discardRectangleMode = VK_DISCARD_RECTANGLE_MODE_EXCLUSIVE_EXT;
-            ci.discardRectangleCount = 1;
-            ci.pDiscardRectangles = &discardRectangles;
-            json = R"({
-            "sType": "VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT",
-            "pNext" : "NULL",
-            "flags": 0,
-            "discardRectangleMode": "VK_DISCARD_RECTANGLE_MODE_EXCLUSIVE_EXT",
-            "discardRectangleCount": 1,
-            "pDiscardRectangles": [
-                {
-                    "offset":
-                    {
-                        "x" : 0,
-                        "y" : 0
-                    },
-                    "extent":
-                    {
-                        "width" : 51,
-                        "height" : 51
-                    }
-                }
-            ]
         })";
             break;
     }

--- a/tests/json_struct_helpers.h
+++ b/tests/json_struct_helpers.h
@@ -1,0 +1,3183 @@
+/*
+ * Copyright (c) 2025 The Khronos Group Inc.
+ * Copyright (c) 2025 RasterGrid Kft.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <vulkan/utility/vk_struct_helper.hpp>
+#include <vulkan/utility/vk_safe_struct.hpp>
+#include <vulkan/vulkan_sc.h>
+
+#include <tuple>        // std::apply
+#include <utility>      // std::forward, std::pair
+#include <string>       // std::string
+#include <string_view>  // std::string_view
+#include <vector>       // std::vector
+#include <optional>     // std::optional
+#include <cmath>        // std::isnan
+
+template <typename Base>
+inline VkBaseInStructure& FindLastLastStructInChain(Base& base) {
+    VkBaseInStructure* prev = reinterpret_cast<VkBaseInStructure*>(&base);
+    VkBaseInStructure* current = prev;
+    while (current->pNext) {
+        prev = current;
+        current = const_cast<VkBaseInStructure*>(current->pNext);
+    }
+    return *current;
+}
+
+// Call 'f' with each element of 't', one after the other.
+template <typename T, typename F>
+void for_each_tuple_elem(T&& t, F&& f) {
+    std::apply([&f](auto&&... args) { (f(std::forward<decltype(args)>(args)), ...); }, std::forward<T>(t));
+}
+
+// Chain the pairs of VkStructures and JSON snippets in 'pNext' onto 'ci' and 'json'.
+template <typename InStructure, typename PNext>
+void ChainPNext(InStructure& ci, std::string& json, const PNext& pNext) {
+    using namespace std::string_literals;
+    for_each_tuple_elem(pNext, [&](auto&& elem) {
+        constexpr std::string_view end_of_pNext = R"("pNext": "NULL")";
+        auto& last = FindLastLastStructInChain(ci);
+        last.pNext = reinterpret_cast<const VkBaseInStructure*>(new decltype(elem.first)(elem.first));
+        json.replace(json.find(end_of_pNext), end_of_pNext.length(), R"("pNext": )"s + elem.second);
+    });
+}
+
+const char* shader_stage_flag_to_string(VkShaderStageFlags flags) {
+    switch (flags) {
+        case VK_SHADER_STAGE_VERTEX_BIT:
+            return "VK_SHADER_STAGE_VERTEX_BIT";
+            break;
+        case VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT:
+            return "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT";
+            break;
+        case VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT:
+            return "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT";
+            break;
+        case VK_SHADER_STAGE_GEOMETRY_BIT:
+            return "VK_SHADER_STAGE_GEOMETRY_BIT";
+            break;
+        case VK_SHADER_STAGE_FRAGMENT_BIT:
+            return "VK_SHADER_STAGE_FRAGMENT_BIT";
+            break;
+        case VK_SHADER_STAGE_COMPUTE_BIT:
+            return "VK_SHADER_STAGE_COMPUTE_BIT";
+            break;
+        case VK_SHADER_STAGE_ALL_GRAPHICS:
+            return "VK_SHADER_STAGE_ALL_GRAPHICS";
+            break;
+        case VK_SHADER_STAGE_ALL:
+            return "VK_SHADER_STAGE_ALL";
+            break;
+        case VK_SHADER_STAGE_RAYGEN_BIT_KHR:
+            return "VK_SHADER_STAGE_RAYGEN_BIT_KHR";
+            break;
+        case VK_SHADER_STAGE_ANY_HIT_BIT_KHR:
+            return "VK_SHADER_STAGE_ANY_HIT_BIT_KHR";
+            break;
+        case VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR:
+            return "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR";
+            break;
+        case VK_SHADER_STAGE_MISS_BIT_KHR:
+            return "VK_SHADER_STAGE_MISS_BIT_KHR";
+            break;
+        case VK_SHADER_STAGE_INTERSECTION_BIT_KHR:
+            return "VK_SHADER_STAGE_INTERSECTION_BIT_KHR";
+            break;
+        case VK_SHADER_STAGE_CALLABLE_BIT_KHR:
+            return "VK_SHADER_STAGE_CALLABLE_BIT_KHR";
+            break;
+        case VK_SHADER_STAGE_TASK_BIT_EXT:
+            return "VK_SHADER_STAGE_TASK_BIT_EXT";
+            break;
+        case VK_SHADER_STAGE_MESH_BIT_EXT:
+            return "VK_SHADER_STAGE_MESH_BIT_EXT";
+            break;
+        case VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI:
+            return "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI";
+            break;
+        case VK_SHADER_STAGE_CLUSTER_CULLING_BIT_HUAWEI:
+            return "VK_SHADER_STAGE_CLUSTER_CULLING_BIT_HUAWEI";
+            break;
+        default:
+            return "Unexpected flag combination";
+            break;
+    }
+};
+
+std::pair<vku::safe_VkSamplerYcbcrConversionCreateInfo, std::string> getVkSamplerYcbcrConversionCreateInfo(uint32_t seed = 0) {
+    VkSamplerYcbcrConversionCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    switch (seed % 2) {
+        case 0:
+            ci.format = VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16;
+            ci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020;
+            ci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_FULL;
+            ci.components.r = VK_COMPONENT_SWIZZLE_A;
+            ci.components.g = VK_COMPONENT_SWIZZLE_B;
+            ci.components.b = VK_COMPONENT_SWIZZLE_G;
+            ci.components.a = VK_COMPONENT_SWIZZLE_R;
+            ci.xChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
+            ci.yChromaOffset = VK_CHROMA_LOCATION_MIDPOINT;
+            ci.chromaFilter = VK_FILTER_CUBIC_EXT;
+            ci.forceExplicitReconstruction = VK_TRUE;
+            json = R"({
+                "sType": "VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO",
+                "pNext": "NULL",
+                "format": "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16",
+                "ycbcrModel": "VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020",
+                "ycbcrRange": "VK_SAMPLER_YCBCR_RANGE_ITU_FULL",
+                "components": {
+                    "r": "VK_COMPONENT_SWIZZLE_A",
+                    "g": "VK_COMPONENT_SWIZZLE_B",
+                    "b": "VK_COMPONENT_SWIZZLE_G",
+                    "a": "VK_COMPONENT_SWIZZLE_R",
+                },
+                "xChromaOffset": "VK_CHROMA_LOCATION_COSITED_EVEN",
+                "yChromaOffset": "VK_CHROMA_LOCATION_MIDPOINT",
+                "chromaFilter": "VK_FILTER_CUBIC_EXT",
+                "forceExplicitReconstruction": "VK_TRUE"
+            })";
+            break;
+        case 1:
+            ci.format = VK_FORMAT_G16B16G16R16_422_UNORM;
+            ci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_IDENTITY;
+            ci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_NARROW;
+            ci.components.r = VK_COMPONENT_SWIZZLE_R;
+            ci.components.g = VK_COMPONENT_SWIZZLE_G;
+            ci.components.b = VK_COMPONENT_SWIZZLE_B;
+            ci.components.a = VK_COMPONENT_SWIZZLE_A;
+            ci.xChromaOffset = VK_CHROMA_LOCATION_MIDPOINT;
+            ci.yChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
+            ci.chromaFilter = VK_FILTER_LINEAR;
+            ci.forceExplicitReconstruction = VK_FALSE;
+            json = R"({
+                "sType": "VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO",
+                "pNext": "NULL",
+                "format": "VK_FORMAT_G16B16G16R16_422_UNORM",
+                "ycbcrModel": "VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_IDENTITY",
+                "ycbcrRange": "VK_SAMPLER_YCBCR_RANGE_ITU_NARROW",
+                "components": {
+                    "r": "VK_COMPONENT_SWIZZLE_R",
+                    "g": "VK_COMPONENT_SWIZZLE_G",
+                    "b": "VK_COMPONENT_SWIZZLE_B",
+                    "a": "VK_COMPONENT_SWIZZLE_A",
+                },
+                "xChromaOffset": "VK_CHROMA_LOCATION_MIDPOINT",
+                "yChromaOffset": "VK_CHROMA_LOCATION_COSITED_EVEN",
+                "chromaFilter": "VK_FILTER_LINEAR",
+                "forceExplicitReconstruction": "VK_FALSE"
+            })";
+            break;
+    }
+
+    return {&ci, json};
+}
+
+std::pair<vku::safe_VkSamplerYcbcrConversionInfo, std::string> getVkSamplerYcbcrConversionInfo(
+    VkSamplerYcbcrConversion conversion = VkSamplerYcbcrConversion(1), std::string name = R"()") {
+    using namespace std::string_literals;
+
+    VkSamplerYcbcrConversionInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    ci.conversion = conversion;
+
+    std::string conversion_str{};
+    if (name.empty()) {
+        conversion_str = std::to_string(reinterpret_cast<std::size_t>(conversion));
+    } else {
+        conversion_str = R"(")"s + name + R"(")";
+    }
+
+    json = R"({
+            "conversion": )"s +
+           conversion_str + R"(,
+            "pNext": "NULL",
+            "sType": "VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO"
+        })";
+
+    return {&ci, json};
+}
+
+std::pair<vku::safe_VkSamplerReductionModeCreateInfo, std::string> getVkSamplerReductionModeCreateInfo(uint32_t seed = 0) {
+    using namespace std::string_literals;
+
+    VkSamplerReductionModeCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    std::string reductionMode_str{};
+    switch (seed % 3) {
+        case 0:
+            ci.reductionMode = VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE;
+            reductionMode_str = R"("VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE")";
+            break;
+        case 1:
+            ci.reductionMode = VK_SAMPLER_REDUCTION_MODE_MIN;
+            reductionMode_str = R"("VK_SAMPLER_REDUCTION_MODE_MIN")";
+            break;
+        case 2:
+            ci.reductionMode = VK_SAMPLER_REDUCTION_MODE_MAX;
+            reductionMode_str = R"("VK_SAMPLER_REDUCTION_MODE_MAX")";
+            break;
+    }
+
+    json = R"({
+        "sType": "VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO",
+            "pNext": "NULL",
+            "reductionMode": )"s +
+           reductionMode_str + R"(
+        })";
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkSamplerCreateInfo, std::string> getVkSamplerCreateInfo(
+    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkSamplerCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    ci.flags = 0;
+    switch (seed % 2) {
+        case 0:
+            ci.magFilter = VK_FILTER_LINEAR;
+            ci.minFilter = VK_FILTER_NEAREST;
+            ci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+            ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+            ci.addressModeV = VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
+            ci.addressModeW = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
+            ci.mipLodBias = 0.5f;
+            ci.anisotropyEnable = VK_TRUE;
+            ci.maxAnisotropy = 2.0f;
+            ci.compareEnable = VK_TRUE;
+            ci.compareOp = VK_COMPARE_OP_ALWAYS;
+            ci.minLod = 1.0f;
+            ci.maxLod = 8.0f;
+            ci.borderColor = VK_BORDER_COLOR_INT_TRANSPARENT_BLACK;
+            ci.unnormalizedCoordinates = VK_TRUE;
+            json = R"({
+            "sType": "VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO",
+            "pNext": "NULL",
+            "flags": 0,
+            "magFilter": "VK_FILTER_LINEAR",
+            "minFilter": "VK_FILTER_NEAREST",
+            "mipmapMode": "VK_SAMPLER_MIPMAP_MODE_LINEAR",
+            "addressModeU": "VK_SAMPLER_ADDRESS_MODE_REPEAT",
+            "addressModeV": "VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT",
+            "addressModeW": "VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE",
+            "mipLodBias": 0.5,
+            "anisotropyEnable": "VK_TRUE",
+            "maxAnisotropy": 2.0,
+            "compareEnable": "VK_TRUE",
+            "compareOp": "VK_COMPARE_OP_ALWAYS",
+            "minLod": 1.0,
+            "maxLod": 8.0,
+            "borderColor": "VK_BORDER_COLOR_INT_TRANSPARENT_BLACK",
+            "unnormalizedCoordinates": "VK_TRUE"
+        })";
+            break;
+        case 1:
+            ci.magFilter = VK_FILTER_CUBIC_EXT;
+            ci.minFilter = VK_FILTER_NEAREST;
+            ci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+            ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
+            ci.addressModeV = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
+            ci.addressModeW = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
+            ci.mipLodBias = 0.5f;
+            ci.anisotropyEnable = VK_FALSE;
+            ci.maxAnisotropy = 2.0f;
+            ci.compareEnable = VK_FALSE;
+            ci.compareOp = VK_COMPARE_OP_LESS_OR_EQUAL;
+            ci.minLod = std::numeric_limits<float>::quiet_NaN();
+            ci.maxLod = VK_LOD_CLAMP_NONE;  // NOTE: float constants can't be serialized as strings
+            ci.borderColor = VK_BORDER_COLOR_FLOAT_CUSTOM_EXT;
+            ci.unnormalizedCoordinates = VK_TRUE;
+            json = R"({
+            "sType": "VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO",
+            "pNext": "NULL",
+            "flags": 0,
+            "magFilter": "VK_FILTER_CUBIC_EXT",
+            "minFilter": "VK_FILTER_NEAREST",
+            "mipmapMode": "VK_SAMPLER_MIPMAP_MODE_LINEAR",
+            "addressModeU": "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER",
+            "addressModeV": "VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE",
+            "addressModeW": "VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE",
+            "mipLodBias": 0.5,
+            "anisotropyEnable": "VK_FALSE",
+            "maxAnisotropy": 2.0,
+            "compareEnable": "VK_FALSE",
+            "compareOp": "VK_COMPARE_OP_LESS_OR_EQUAL",
+            "minLod": "NaN",
+            "maxLod": 1000.0,
+            "borderColor": "VK_BORDER_COLOR_FLOAT_CUSTOM_EXT",
+            "unnormalizedCoordinates": "VK_TRUE"
+        })";
+            break;
+    }
+
+    ChainPNext(ci, json, pNext);
+
+    return {&ci, json};
+}
+
+std::pair<vku::safe_VkDescriptorSetLayoutBindingFlagsCreateInfo, std::string> getVkDescriptorSetLayoutBindingFlagsCreateInfo(
+    uint32_t seed = 0, uint32_t count = 1) {
+    using namespace std::string_literals;
+
+    VkDescriptorSetLayoutBindingFlagsCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    ci.bindingCount = count;
+
+    std::vector<VkDescriptorBindingFlags> bindingFlags{};
+    std::string pBindingFlags_str{};
+    switch (seed % 2) {
+        default:
+            bindingFlags.resize(count, VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT);
+            ci.pBindingFlags = bindingFlags.data();
+            pBindingFlags_str = "[";
+            for (uint32_t i = 0; i < count; ++i) {
+                pBindingFlags_str += R"("VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT")";
+                if (i != count - 1) {
+                    pBindingFlags_str += ",";
+                }
+            }
+            pBindingFlags_str += "]";
+            break;
+    }
+
+    json = R"({
+                "sType" : "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO",
+                "pNext": "NULL",
+                "bindingCount": )"s +
+           std::to_string(ci.bindingCount) + R"(,
+                "pBindingFlags": )"s +
+           pBindingFlags_str + R"(
+            })";
+
+    return {&ci, json};
+}
+
+struct DescriptorSetLayoutBinding {
+    uint32_t descriptorCount;
+    VkShaderStageFlags stageFlags;
+    const std::optional<VkSampler> immutableSampler = std::nullopt;
+    const std::optional<std::string> immutableSamplerName = std::nullopt;
+};
+
+template <typename... InStructure>
+std::pair<vku::safe_VkDescriptorSetLayoutCreateInfo, std::string> getVkDescriptorSetLayoutCreateInfo(
+    uint32_t seed = 0, std::initializer_list<DescriptorSetLayoutBinding> immutable_samplers = {{1, VK_SHADER_STAGE_ALL}},
+    std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkDescriptorSetLayoutCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    std::vector<VkDescriptorSetLayoutBinding> bindings{};
+    std::string pBindingFlags_str{};
+    ci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT;
+    switch (seed % 2) {
+        default:
+            if (std::empty(immutable_samplers)) {
+                pBindingFlags_str = R"("NULL")";
+            } else {
+                pBindingFlags_str = "[";
+                for (auto it = immutable_samplers.begin(); it != immutable_samplers.end(); ++it) {
+                    bindings.push_back(VkDescriptorSetLayoutBinding{});
+                    bindings.back().binding = static_cast<uint32_t>(std::distance(immutable_samplers.begin(), it));
+                    bindings.back().descriptorType =
+                        it->immutableSampler ? VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER : VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+                    bindings.back().descriptorCount = 1;
+                    bindings.back().stageFlags = it->stageFlags;
+                    bindings.back().pImmutableSamplers = it->immutableSampler ? &it->immutableSampler.value() : nullptr;
+                    pBindingFlags_str +=
+                        R"({
+                        "binding": )"s +
+                        std::to_string(std::distance(immutable_samplers.begin(), it)) + R"(,
+                        "descriptorType": )"s +
+                        (it->immutableSampler ? R"("VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER")"
+                                              : R"("VK_DESCRIPTOR_TYPE_STORAGE_BUFFER")") +
+                        R"(,
+                        "descriptorCount": 1,
+                        "stageFlags": ")"s +
+                        shader_stage_flag_to_string(it->stageFlags) + R"(",
+                        "pImmutableSamplers": )"s +
+                        (it->immutableSampler
+                             ? ("["s +
+                                (it->immutableSamplerName
+                                     ? (R"(")"s + it->immutableSamplerName.value() + R"(")")
+                                     : std::to_string(reinterpret_cast<std::size_t>(it->immutableSampler.value()))) +
+                                "]")
+                             : R"("NULL")"s) +
+                        R"(
+                })";
+                    if (std::next(it) != immutable_samplers.end()) {
+                        pBindingFlags_str += ",";
+                    }
+                }
+                pBindingFlags_str += "]";
+            }
+            break;
+    }
+    ci.bindingCount = static_cast<uint32_t>(immutable_samplers.size());
+    ci.pBindings = bindings.data();
+
+    json = R"({
+                "sType" : "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO",
+                "pNext": "NULL",
+                "flags": "VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT",
+                "bindingCount": )"s +
+           std::to_string(immutable_samplers.size()) + R"(,
+                "pBindings": )"s +
+           pBindingFlags_str + R"(
+            })";
+
+    ChainPNext(ci, json, pNext);
+
+    return {&ci, json};
+}
+
+struct DescriptorSetLayout {
+    const std::optional<VkDescriptorSetLayout> descriptorSetLayout = std::nullopt;
+    const std::optional<std::string> descriptorSetLayoutName = std::nullopt;
+};
+
+template <typename... InStructure>
+std::pair<vku::safe_VkPipelineLayoutCreateInfo, std::string> getVkPipelineLayoutCreateInfo(
+    uint32_t seed = 0, std::initializer_list<DescriptorSetLayout> descriptor_set_layouts = {{VkDescriptorSetLayout(0)}},
+    std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkPipelineLayoutCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    std::vector<VkPushConstantRange> pushConstantRanges{};
+    std::vector<VkDescriptorSetLayout> setLayouts{};
+    std::string pPushConstantRanges_str{};
+    std::string pSetLayouts_str{};
+    switch (seed % 2) {
+        default:
+            pushConstantRanges.resize(1);
+            pushConstantRanges.back().stageFlags = VK_SHADER_STAGE_ALL_GRAPHICS | VK_SHADER_STAGE_COMPUTE_BIT;
+            pushConstantRanges.back().offset = 0;
+            pushConstantRanges.back().size = 4;
+            ci.pushConstantRangeCount = static_cast<uint32_t>(pushConstantRanges.size());
+            ci.pPushConstantRanges = pushConstantRanges.data();
+            pPushConstantRanges_str +=
+                R"([{"stageFlags": "VK_SHADER_STAGE_ALL_GRAPHICS | VK_SHADER_STAGE_COMPUTE_BIT", "offset": 0, "size": 4}])";
+            break;
+    }
+
+    if (std::empty(descriptor_set_layouts)) {
+        pSetLayouts_str = R"("NULL")";
+    } else {
+        pSetLayouts_str = "[";
+        for (auto it = descriptor_set_layouts.begin(); it != descriptor_set_layouts.end(); ++it) {
+            setLayouts.push_back(it->descriptorSetLayout.value());
+            pSetLayouts_str +=
+                it->descriptorSetLayout
+                    ? (it->descriptorSetLayoutName ? (R"(")"s + it->descriptorSetLayoutName.value() + R"(")")
+                                                   : std::to_string(reinterpret_cast<std::size_t>(it->descriptorSetLayout.value())))
+                    : R"("NULL")"s;
+            if (std::next(it) != descriptor_set_layouts.end()) {
+                pSetLayouts_str += ",";
+            }
+        }
+        pSetLayouts_str += "]";
+    }
+    ci.setLayoutCount = static_cast<uint32_t>(setLayouts.size());
+    ci.pSetLayouts = setLayouts.data();
+
+    json = R"({
+                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO",
+                "pNext": "NULL",
+                "flags": 0,
+                "setLayoutCount": )"s +
+           std::to_string(setLayouts.size()) + R"(,
+                "pSetLayouts": )" +
+           pSetLayouts_str + R"(,
+                "pushConstantRangeCount": )" +
+           std::to_string(pushConstantRanges.size()) + R"(,
+                "pPushConstantRanges": )" +
+           pPushConstantRanges_str + R"(,
+            })";
+
+    ChainPNext(ci, json, pNext);
+
+    return {&ci, json};
+}
+
+std::pair<vku::safe_VkPipelineShaderStageRequiredSubgroupSizeCreateInfo, std::string>
+getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo(uint32_t seed = 0) {
+    using namespace std::string_literals;
+
+    VkPipelineShaderStageRequiredSubgroupSizeCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    switch (seed % 3) {
+        case 0:
+            ci.requiredSubgroupSize = 32;
+            break;
+        case 1:
+            ci.requiredSubgroupSize = 64;
+            break;
+        case 2:
+            ci.requiredSubgroupSize = 256;
+            break;
+    }
+
+    json = R"({
+        "sType": "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO",
+            "pNext": "NULL",
+            "requiredSubgroupSize": )"s +
+           std::to_string(ci.requiredSubgroupSize) + R"(
+        })";
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkPipelineShaderStageCreateInfo, std::string> getVkPipelineShaderStageCreateInfo(
+    uint32_t seed = 0, VkShaderStageFlagBits stage = VK_SHADER_STAGE_COMPUTE_BIT,
+    std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkPipelineShaderStageCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    std::string pSpecializationInfo_str{};
+    VkSpecializationMapEntry mapEntry{};
+    int32_t data{};
+    VkSpecializationInfo specializationInfo{};
+    ci.flags = VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT;
+    ci.stage = stage;
+    ci.module = VK_NULL_HANDLE;
+    ci.pName = "main";
+    switch (seed % 2) {
+        case 0:
+            mapEntry = VkSpecializationMapEntry{0, 0, 4};
+            data = 12345;
+            specializationInfo = VkSpecializationInfo{1, &mapEntry, 4, &data};
+            ci.pSpecializationInfo = &specializationInfo;
+            pSpecializationInfo_str = R"({
+            "mapEntryCount" : 1,
+            "pMapEntries" : [
+                {
+                    "constantID" : 0,
+                    "offset" : 0,
+                    "size" : 4
+                },
+            ],
+            "dataSize" : 4,
+            "pData" : "OTAAAA==",
+            
+        })";
+            break;
+        case 1:
+            pSpecializationInfo_str = "NULL";
+            break;
+    }
+
+    json = R"({
+        "sType": "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
+        "pNext": "NULL",
+        "flags": "VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT",
+        "module": "",
+        "pName": "main",
+        "pSpecializationInfo" : )"s +
+           pSpecializationInfo_str + R"(,
+        "stage" : ")" +
+           shader_stage_flag_to_string(stage) + R"(",
+    })";
+
+    ChainPNext(ci, json, pNext);
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkComputePipelineCreateInfo, std::string> getVkComputePipelineCreateInfo(
+    std::pair<vku::safe_VkPipelineShaderStageCreateInfo, std::string> stage) {
+    using namespace std::string_literals;
+
+    VkComputePipelineCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    ci.stage = *stage.first.ptr();
+
+    json = R"({
+            "basePipelineHandle" : "",
+            "basePipelineIndex" : 0,
+            "flags" : 0,
+            "layout" : "",
+            "pNext" : "NULL",
+            "sType" : "VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO",
+            "stage" : )" +
+           stage.second + R"(
+        })";
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkSubpassDescription, std::string> getVkSubpassDescription(uint32_t seed = 0) {
+    using namespace std::string_literals;
+
+    VkSubpassDescription sd{};
+    std::string json{};
+
+    sd.flags = 0;
+    sd.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    VkAttachmentReference inputAttachments{}, colorAttachments{}, resolveAttachments{}, depthAttachments{};
+    switch (seed % 2) {
+        case 0:
+            inputAttachments = VkAttachmentReference{567, VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL};
+            colorAttachments = VkAttachmentReference{VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_UNDEFINED};
+            resolveAttachments = VkAttachmentReference{VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_UNDEFINED};
+            depthAttachments = VkAttachmentReference{VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_UNDEFINED};
+            sd.inputAttachmentCount = 1;
+            sd.pInputAttachments = &inputAttachments;
+            sd.colorAttachmentCount = 1;
+            sd.pColorAttachments = &colorAttachments;
+            sd.pResolveAttachments = &resolveAttachments;
+            sd.pDepthStencilAttachment = &depthAttachments;
+            sd.preserveAttachmentCount = 0;
+            sd.pPreserveAttachments = nullptr;
+            json = R"({
+                "flags": 0,
+                "pipelineBindPoint": "VK_PIPELINE_BIND_POINT_GRAPHICS",
+                "inputAttachmentCount": 1,
+                "pInputAttachments": [
+                    {
+                        "attachment": 567,
+                        "layout": "VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL"
+                    }
+                ],
+                "colorAttachmentCount": 1,
+                "pColorAttachments": [
+                    {
+                        "attachment": 4294967295,
+                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED"
+                    }
+                ],
+                "pResolveAttachments": [
+                    {
+                        "attachment": 4294967295,
+                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED"
+                    }
+                ],
+                "pDepthStencilAttachment": {
+                    "attachment": 4294967295,
+                    "layout": "VK_IMAGE_LAYOUT_UNDEFINED"
+                },
+                "preserveAttachmentCount": 0,
+                "pPreserveAttachments": "NULL"
+            })";
+            break;
+        case 1:
+            colorAttachments = VkAttachmentReference{567, VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL_KHR};
+            resolveAttachments = VkAttachmentReference{VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_UNDEFINED};
+            depthAttachments = VkAttachmentReference{VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_UNDEFINED};
+            sd.inputAttachmentCount = 0;
+            sd.pInputAttachments = nullptr;
+            sd.colorAttachmentCount = 1;
+            sd.pColorAttachments = &colorAttachments;
+            sd.pResolveAttachments = &resolveAttachments;
+            sd.pDepthStencilAttachment = &depthAttachments;
+            sd.preserveAttachmentCount = 0;
+            sd.pPreserveAttachments = nullptr;
+            json = R"({
+                "flags": 0,
+                "pipelineBindPoint": "VK_PIPELINE_BIND_POINT_GRAPHICS",
+                "inputAttachmentCount": 0,
+                "pInputAttachments": "NULL",
+                "colorAttachmentCount": 1,
+                "pColorAttachments": [
+                    {
+                        "attachment": 567,
+                        "layout": "VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL"
+                    }
+                ],
+                "pResolveAttachments": [
+                    {
+                        "attachment": 4294967295,
+                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED"
+                    }
+                ],
+                "pDepthStencilAttachment": {
+                    "attachment": 4294967295,
+                    "layout": "VK_IMAGE_LAYOUT_UNDEFINED"
+                },
+                "preserveAttachmentCount": 0,
+                "pPreserveAttachments": "NULL"
+            })";
+            break;
+    }
+
+    return {&sd, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkRenderPassInputAttachmentAspectCreateInfo, std::string> getVkRenderPassInputAttachmentAspectCreateInfo(
+    uint32_t seed = 0) {
+    using namespace std::string_literals;
+
+    VkRenderPassInputAttachmentAspectCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    VkInputAttachmentAspectReference aspectReference{};
+    switch (seed % 2) {
+        default:
+            aspectReference = {1, 2, VK_IMAGE_ASPECT_COLOR_BIT};
+            ci.aspectReferenceCount = 1;
+            ci.pAspectReferences = &aspectReference;
+            json = R"({
+            "sType" : "VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO",
+            "pNext": "NULL",
+            "aspectReferenceCount": 1,
+            "pAspectReferences": [
+                {
+                    "subpass": 1,
+                    "inputAttachmentIndex": 2,
+                    "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
+                }
+            ]
+        })";
+            break;
+    }
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkRenderPassMultiviewCreateInfo, std::string> getVkRenderPassMultiviewCreateInfo(uint32_t seed = 0) {
+    using namespace std::string_literals;
+
+    VkRenderPassMultiviewCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    std::vector<uint32_t> viewMasks;
+    std::vector<int32_t> viewOffsets;
+    std::vector<uint32_t> correlationMasks;
+    switch (seed % 2) {
+        default:
+            viewMasks = {1};
+            viewOffsets = {0, 1};
+            correlationMasks = {8};
+            ci.subpassCount = static_cast<uint32_t>(viewMasks.size());
+            ci.pViewMasks = viewMasks.data();
+            ci.dependencyCount = static_cast<uint32_t>(viewOffsets.size());
+            ci.pViewOffsets = viewOffsets.data();
+            ci.correlationMaskCount = static_cast<uint32_t>(correlationMasks.size());
+            ci.pCorrelationMasks = correlationMasks.data();
+            json = R"({
+                "sType" : "VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO",
+                "pNext": "NULL",
+                "subpassCount": 1,
+                "pViewMasks": [ 1 ],
+                "dependencyCount": 2,
+                "pViewOffsets": [ 0, 1 ],
+                "correlationMaskCount": 1,
+                "pCorrelationMasks": [ 8 ]
+            })";
+            break;
+    }
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkRenderPassCreateInfo, std::string> getVkRenderPassCreateInfo(
+    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkRenderPassCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    VkSubpassDependency dependencies[1] = {};
+    vku::safe_VkSubpassDescription subpasses[2] = {};
+    switch (seed % 2) {
+        default:
+            VkAttachmentDescription attachments[1] = {};
+            attachments[0].flags = VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT;
+            attachments[0].format = VK_FORMAT_R8G8_USCALED;
+            attachments[0].samples = VK_SAMPLE_COUNT_8_BIT;
+            attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+            attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+            attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+            attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+            attachments[0].initialLayout = VK_IMAGE_LAYOUT_GENERAL;
+            attachments[0].finalLayout = VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR;
+            dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
+            dependencies[0].dstSubpass = 2345;
+            dependencies[0].srcStageMask = VK_PIPELINE_STAGE_NONE_KHR;
+            dependencies[0].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+            dependencies[0].srcAccessMask = VK_ACCESS_NONE_KHR;
+            dependencies[0].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+            dependencies[0].dependencyFlags = VK_DEPENDENCY_DEVICE_GROUP_BIT;
+            auto [sd1, sd1_json] = getVkSubpassDescription(seed);
+            auto [sd2, sd2_json] = getVkSubpassDescription(seed + 1);
+            subpasses[0] = sd1;
+            subpasses[1] = sd2;
+            ci.attachmentCount = 1;
+            ci.pAttachments = attachments;
+            ci.subpassCount = 2;
+            ci.pSubpasses = reinterpret_cast<const VkSubpassDescription*>(subpasses);
+            ci.dependencyCount = 1;
+            ci.pDependencies = dependencies;
+            json = R"({
+            "sType" : "VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO",
+            "pNext": "NULL",
+            "flags": 0,
+            "attachmentCount": 1,
+            "pAttachments": [
+                {
+                    "flags": "VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT",
+                    "format": "VK_FORMAT_R8G8_USCALED",
+                    "samples": "VK_SAMPLE_COUNT_8_BIT",
+                    "loadOp": "VK_ATTACHMENT_LOAD_OP_DONT_CARE",
+                    "storeOp": "VK_ATTACHMENT_STORE_OP_STORE",
+                    "stencilLoadOp": "VK_ATTACHMENT_LOAD_OP_LOAD",
+                    "stencilStoreOp": "VK_ATTACHMENT_STORE_OP_DONT_CARE",
+                    "initialLayout": "VK_IMAGE_LAYOUT_GENERAL",
+                    "finalLayout": "VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR"
+                }
+            ],
+            "subpassCount": 2,
+            "pSubpasses": [ )" +
+                   sd1_json + R"(,)" + sd2_json + R"(],
+            "dependencyCount": 1,
+            "pDependencies": [
+                {
+                    "srcSubpass": 4294967295,
+                    "dstSubpass": 2345,
+                    "srcStageMask": 0,
+                    "dstStageMask": "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                    "srcAccessMask": 0,
+                    "dstAccessMask": "VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT",
+                    "dependencyFlags": "VK_DEPENDENCY_DEVICE_GROUP_BIT"
+                }
+            ]
+        })";
+            break;
+    }
+
+    ChainPNext(ci, json, pNext);
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkAttachmentDescriptionStencilLayout, std::string> getVkAttachmentDescriptionStencilLayout(uint32_t seed = 0) {
+    using namespace std::string_literals;
+
+    VkAttachmentDescriptionStencilLayout ci = vku::InitStructHelper();
+    std::string json{};
+
+    switch (seed % 2) {
+        default:
+            ci.stencilInitialLayout = VK_IMAGE_LAYOUT_GENERAL;
+            ci.stencilFinalLayout = VK_IMAGE_LAYOUT_GENERAL;
+            json = R"({
+            "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT",
+            "pNext": "NULL",
+            "stencilInitialLayout": "VK_IMAGE_LAYOUT_GENERAL",
+            "stencilFinalLayout": "VK_IMAGE_LAYOUT_GENERAL"
+        })";
+            break;
+    }
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkAttachmentDescription2, std::string> getVkAttachmentDescription2(
+    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkAttachmentDescription2 ci = vku::InitStructHelper();
+    std::string json{};
+
+    switch (seed % 2) {
+        default:
+            ci.flags = VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT;
+            ci.format = VK_FORMAT_R8G8_USCALED;
+            ci.samples = VK_SAMPLE_COUNT_8_BIT;
+            ci.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+            ci.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+            ci.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+            ci.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+            ci.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
+            ci.finalLayout = VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR;
+            json = R"({
+            "sType" : "VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2",
+            "pNext": "NULL",
+            "flags": "VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT",
+            "format": "VK_FORMAT_R8G8_USCALED",
+            "samples": "VK_SAMPLE_COUNT_8_BIT",
+            "loadOp": "VK_ATTACHMENT_LOAD_OP_DONT_CARE",
+            "storeOp": "VK_ATTACHMENT_STORE_OP_STORE",
+            "stencilLoadOp": "VK_ATTACHMENT_LOAD_OP_LOAD",
+            "stencilStoreOp": "VK_ATTACHMENT_STORE_OP_DONT_CARE",
+            "initialLayout": "VK_IMAGE_LAYOUT_GENERAL",
+            "finalLayout": "VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR"
+        })";
+            break;
+    }
+
+    ChainPNext(ci, json, pNext);
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkAttachmentReference2, std::string> getVkAttachmentReference2(
+    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkAttachmentReference2 ci = vku::InitStructHelper();
+    std::string json{};
+
+    switch (seed % 2) {
+        case 0:
+            ci.attachment = 0;
+            ci.layout = VK_IMAGE_LAYOUT_GENERAL;
+            ci.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            json = R"({
+            "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
+            "pNext": "NULL",
+            "attachment": 0,
+            "layout": "VK_IMAGE_LAYOUT_GENERAL",
+            "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
+        })";
+            break;
+        case 1:
+            ci.attachment = 1;
+            ci.layout = VK_IMAGE_LAYOUT_GENERAL;
+            ci.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+            json = R"({
+            "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
+            "pNext": "NULL",
+            "attachment": 1,
+            "layout": "VK_IMAGE_LAYOUT_GENERAL",
+            "aspectMask": "VK_IMAGE_ASPECT_DEPTH_BIT"
+        })";
+            break;
+    }
+
+    ChainPNext(ci, json, pNext);
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkMemoryBarrier2, std::string> getVkMemoryBarrier2KHR(uint32_t seed = 0) {
+    using namespace std::string_literals;
+
+    VkMemoryBarrier2KHR ci = vku::InitStructHelper();
+    std::string json{};
+
+    switch (seed % 2) {
+        default:
+            ci.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+            ci.srcAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT;
+            ci.dstStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+            ci.dstAccessMask = VK_ACCESS_2_COMMAND_PREPROCESS_READ_BIT_NV;
+            json = R"({
+            "sType" : "VK_STRUCTURE_TYPE_MEMORY_BARRIER_2",
+            "pNext": "NULL",
+            "srcStageMask": "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
+            "srcAccessMask": "VK_ACCESS_2_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT",
+            "dstStageMask": "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
+            "dstAccessMask": "VK_ACCESS_2_COMMAND_PREPROCESS_READ_BIT_EXT"
+        })";
+            break;
+    }
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkSubpassDependency2, std::string> getVkSubpassDependency2(
+    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkSubpassDependency2 ci = vku::InitStructHelper();
+    std::string json{};
+
+    switch (seed % 2) {
+        default:
+            ci.srcSubpass = VK_SUBPASS_EXTERNAL;
+            ci.dstSubpass = 2345;
+            ci.srcStageMask = VK_PIPELINE_STAGE_NONE_KHR;
+            ci.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+            ci.srcAccessMask = VK_ACCESS_NONE_KHR;
+            ci.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+            ci.dependencyFlags = VK_DEPENDENCY_DEVICE_GROUP_BIT;
+            json = R"({
+            "sType" : "VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2",
+            "pNext": "NULL",
+            "srcSubpass": 4294967295,
+            "dstSubpass": 2345,
+            "srcStageMask": 0,
+            "dstStageMask": "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+            "srcAccessMask": 0,
+            "dstAccessMask": "VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT",
+            "dependencyFlags": "VK_DEPENDENCY_DEVICE_GROUP_BIT",
+            "viewOffset": 0
+        })";
+            break;
+    }
+
+    ChainPNext(ci, json, pNext);
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkSubpassDescriptionDepthStencilResolve, std::string> getVkSubpassDescriptionDepthStencilResolve(
+    uint32_t seed = 0) {
+    using namespace std::string_literals;
+
+    VkSubpassDescriptionDepthStencilResolve ci = vku::InitStructHelper();
+    std::string json{};
+
+    auto [dsra_ci, dsra_json] = getVkAttachmentReference2(1);
+    switch (seed % 2) {
+        default:
+            ci.depthResolveMode = VK_RESOLVE_MODE_MIN_BIT;
+            ci.stencilResolveMode = VK_RESOLVE_MODE_MAX_BIT;
+            ci.pDepthStencilResolveAttachment = dsra_ci.ptr();
+            json = R"({
+            "sType" : "VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE",
+            "pNext": "NULL",
+            "depthResolveMode": "VK_RESOLVE_MODE_MIN_BIT",
+            "stencilResolveMode": "VK_RESOLVE_MODE_MAX_BIT",
+            "pDepthStencilResolveAttachment": )" +
+                   dsra_json + R"(
+        })";
+            break;
+    }
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkFragmentShadingRateAttachmentInfoKHR, std::string> getVkFragmentShadingRateAttachmentInfoKHR(
+    uint32_t seed = 0) {
+    using namespace std::string_literals;
+
+    VkFragmentShadingRateAttachmentInfoKHR ci = vku::InitStructHelper();
+    std::string json{};
+
+    auto [fsra_ci, fsra_json] = getVkAttachmentReference2(0);
+    switch (seed % 2) {
+        default:
+            ci.pFragmentShadingRateAttachment = fsra_ci.ptr();
+            ci.shadingRateAttachmentTexelSize.width = 4;
+            ci.shadingRateAttachmentTexelSize.height = 4;
+            json = R"({
+            "sType" : "VK_STRUCTURE_TYPE_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR",
+            "pNext": "NULL",
+            "pFragmentShadingRateAttachment": )" +
+                   fsra_json + R"(,
+            "shadingRateAttachmentTexelSize": {
+                "width": 4,
+                "height": 4
+            }
+        })";
+            break;
+    }
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkSubpassDescription2, std::string> getVkSubpassDescription2(uint32_t seed = 0) {
+    using namespace std::string_literals;
+
+    VkSubpassDescription2 sd = vku::InitStructHelper();
+    std::string json{};
+
+    sd.flags = 0;
+    sd.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    auto [colorar_ci, colorar_json] = getVkAttachmentReference2(0);
+    VkAttachmentReference2 inputAttachments = vku::InitStructHelper(), colorAttachments = vku::InitStructHelper(),
+                           resolveAttachments = vku::InitStructHelper(), depthAttachments = vku::InitStructHelper();
+    inputAttachments.attachment = VK_ATTACHMENT_UNUSED;
+    inputAttachments.layout = VK_IMAGE_LAYOUT_UNDEFINED;
+    inputAttachments.aspectMask = VK_IMAGE_ASPECT_NONE_KHR;
+    colorAttachments.attachment = VK_ATTACHMENT_UNUSED;
+    colorAttachments.layout = VK_IMAGE_LAYOUT_UNDEFINED;
+    colorAttachments.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    resolveAttachments.attachment = VK_ATTACHMENT_UNUSED;
+    resolveAttachments.layout = VK_IMAGE_LAYOUT_UNDEFINED;
+    resolveAttachments.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    depthAttachments.attachment = VK_ATTACHMENT_UNUSED;
+    depthAttachments.layout = VK_IMAGE_LAYOUT_UNDEFINED;
+    depthAttachments.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+    switch (seed % 2) {
+        case 0:
+            sd.viewMask = (uint32_t)~0;
+            sd.inputAttachmentCount = 1;
+            sd.pInputAttachments = &inputAttachments;
+            sd.colorAttachmentCount = 1;
+            sd.pColorAttachments = colorar_ci.ptr();
+            sd.pResolveAttachments = &resolveAttachments;
+            sd.pDepthStencilAttachment = &depthAttachments;
+            sd.preserveAttachmentCount = 0;
+            sd.pPreserveAttachments = nullptr;
+            json = R"({
+                "sType" : "VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2",
+                "pNext": "NULL",
+                "flags": 0,
+                "pipelineBindPoint": "VK_PIPELINE_BIND_POINT_GRAPHICS",
+                "viewMask": 4294967295,
+                "inputAttachmentCount": 1,
+                "pInputAttachments": [
+                    {
+                        "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
+                        "pNext": "NULL",
+                        "attachment": 4294967295,
+                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED",
+                        "aspectMask": 0
+                    }
+                ],
+                "colorAttachmentCount": 1,
+                "pColorAttachments": [
+                    )" +
+                   colorar_json + R"(
+                ],
+                "pResolveAttachments": [
+                    {
+                        "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
+                        "pNext": "NULL",
+                        "attachment": 4294967295,
+                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED",
+                        "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
+                    }
+                ],
+                "pDepthStencilAttachment": {
+                    "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
+                    "pNext": "NULL",
+                    "attachment": 4294967295,
+                    "layout": "VK_IMAGE_LAYOUT_UNDEFINED",
+                    "aspectMask": "VK_IMAGE_ASPECT_DEPTH_BIT"
+                },
+                "preserveAttachmentCount": 0,
+                "pPreserveAttachments": "NULL"
+            })";
+
+            ChainPNext(sd, json,
+                       std::make_tuple(getVkFragmentShadingRateAttachmentInfoKHR(), getVkSubpassDescriptionDepthStencilResolve()));
+            break;
+        case 1:
+            sd.viewMask = (uint32_t)~0;
+            sd.inputAttachmentCount = 0;
+            sd.pInputAttachments = nullptr;
+            sd.colorAttachmentCount = 1;
+            sd.pColorAttachments = &colorAttachments;
+            sd.pResolveAttachments = &resolveAttachments;
+            sd.pDepthStencilAttachment = &depthAttachments;
+            sd.preserveAttachmentCount = 0;
+            sd.pPreserveAttachments = nullptr;
+            json = R"({
+                "sType" : "VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2",
+                "pNext": "NULL",
+                "flags": 0,
+                "pipelineBindPoint": "VK_PIPELINE_BIND_POINT_GRAPHICS",
+                "viewMask": 4294967295,
+                "inputAttachmentCount": 0,
+                "pInputAttachments": "NULL",
+                "colorAttachmentCount": 1,
+                "pColorAttachments": [
+                    {
+                        "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
+                        "pNext": "NULL",
+                        "attachment": 4294967295,
+                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED",
+                        "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
+                    }
+                ],
+                "pResolveAttachments": [
+                    {
+                        "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
+                        "pNext": "NULL",
+                        "attachment": 4294967295,
+                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED",
+                        "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
+                    }
+                ],
+                "pDepthStencilAttachment": {
+                    "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
+                    "pNext": "NULL",
+                    "attachment": 4294967295,
+                    "layout": "VK_IMAGE_LAYOUT_UNDEFINED",
+                    "aspectMask": "VK_IMAGE_ASPECT_DEPTH_BIT"
+                },
+                "preserveAttachmentCount": 0,
+                "pPreserveAttachments": "NULL"
+            })";
+            break;
+    }
+
+    return {&sd, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkRenderPassCreateInfo2, std::string> getVkRenderPassCreateInfo2(
+    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkRenderPassCreateInfo2 ci = vku::InitStructHelper();
+    std::string json{};
+
+    auto [dependencies, dependencies_json] = getVkSubpassDependency2(0, std::make_tuple(getVkMemoryBarrier2KHR()));
+    vku::safe_VkSubpassDescription2 subpasses[2] = {};
+    switch (seed % 2) {
+        default:
+            VkAttachmentDescription2 attachments[1] = {vku::InitStructHelper()};
+            attachments[0].flags = VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT;
+            attachments[0].format = VK_FORMAT_R8G8_USCALED;
+            attachments[0].samples = VK_SAMPLE_COUNT_8_BIT;
+            attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+            attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+            attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+            attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+            attachments[0].initialLayout = VK_IMAGE_LAYOUT_GENERAL;
+            attachments[0].finalLayout = VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR;
+            dependencies.srcSubpass = VK_SUBPASS_EXTERNAL;
+            dependencies.dstSubpass = 2345;
+            dependencies.srcStageMask = VK_PIPELINE_STAGE_NONE_KHR;
+            dependencies.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+            dependencies.srcAccessMask = VK_ACCESS_NONE_KHR;
+            dependencies.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+            dependencies.dependencyFlags = VK_DEPENDENCY_DEVICE_GROUP_BIT;
+            auto [sd1, sd1_json] = getVkSubpassDescription2(seed);
+            auto [sd2, sd2_json] = getVkSubpassDescription2(seed + 1);
+            subpasses[0] = sd1;
+            subpasses[1] = sd2;
+            ci.attachmentCount = 1;
+            ci.pAttachments = attachments;
+            ci.subpassCount = 2;
+            ci.pSubpasses = reinterpret_cast<const VkSubpassDescription2*>(subpasses);
+            ci.dependencyCount = 1;
+            ci.pDependencies = dependencies.ptr();
+            json = R"({
+            "sType" : "VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2",
+            "pNext": "NULL",
+            "flags": 0,
+            "attachmentCount": 1,
+            "pAttachments": [
+                {
+                    "pNext" : "NULL",
+                    "sType" : "VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2",
+                    "flags": "VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT",
+                    "format": "VK_FORMAT_R8G8_USCALED",
+                    "samples": "VK_SAMPLE_COUNT_8_BIT",
+                    "loadOp": "VK_ATTACHMENT_LOAD_OP_DONT_CARE",
+                    "storeOp": "VK_ATTACHMENT_STORE_OP_STORE",
+                    "stencilLoadOp": "VK_ATTACHMENT_LOAD_OP_LOAD",
+                    "stencilStoreOp": "VK_ATTACHMENT_STORE_OP_DONT_CARE",
+                    "initialLayout": "VK_IMAGE_LAYOUT_GENERAL",
+                    "finalLayout": "VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR"
+                }
+            ],
+            "correlatedViewMaskCount" : 0,
+            "pCorrelatedViewMasks" : "NULL",
+            "subpassCount": 2,
+            "pSubpasses": [ )" +
+                   sd1_json + R"(,)" + sd2_json + R"(],
+            "dependencyCount": 1,
+            "pDependencies": [
+                )" +
+                   dependencies_json + R"(
+            ]
+        })";
+            break;
+    }
+
+    ChainPNext(ci, json, pNext);
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkPipelineVertexInputStateCreateInfo, std::string> getVkPipelineVertexInputStateCreateInfo(
+    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkPipelineVertexInputStateCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    switch (seed % 2) {
+        default:
+            VkVertexInputBindingDescription vertexBindingDescriptions[1] = {{0, 32, VK_VERTEX_INPUT_RATE_VERTEX}};
+            VkVertexInputAttributeDescription vertexAttributeDescriptions[2] = {{0, 0, VK_FORMAT_R32G32B32A32_SFLOAT, 0},
+                                                                                {1, 0, VK_FORMAT_R32G32B32A32_SFLOAT, 16}};
+            ci.vertexBindingDescriptionCount = 1;
+            ci.pVertexBindingDescriptions = vertexBindingDescriptions;
+            ci.vertexAttributeDescriptionCount = 2;
+            ci.pVertexAttributeDescriptions = vertexAttributeDescriptions;
+            json = R"({
+            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO",
+            "pNext":"NULL",
+            "flags" : 0,
+            "vertexBindingDescriptionCount" : 1,
+            "pVertexBindingDescriptions": [
+                {
+                    "binding" : 0,
+                    "stride" : 32,
+                    "inputRate" : "VK_VERTEX_INPUT_RATE_VERTEX"
+                }
+            ],
+            "vertexAttributeDescriptionCount" : 2,
+            "pVertexAttributeDescriptions": [
+                {
+                    "location" : 0,
+                    "binding" : 0,
+                    "format" : "VK_FORMAT_R32G32B32A32_SFLOAT",
+                    "offset" : 0
+                },
+                {
+                    "location" : 1,
+                    "binding" : 0,
+                    "format" : "VK_FORMAT_R32G32B32A32_SFLOAT",
+                    "offset" : 16
+                }
+            ]
+        })";
+            break;
+    }
+
+    ChainPNext(ci, json, pNext);
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkPipelineInputAssemblyStateCreateInfo, std::string> getVkPipelineInputAssemblyStateCreateInfo(
+    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkPipelineInputAssemblyStateCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    switch (seed % 2) {
+        default:
+            ci.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
+            ci.primitiveRestartEnable = VK_FALSE;
+            json = R"({
+            "sType": "VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO",
+            "pNext": "NULL",
+            "flags": 0,
+            "topology": "VK_PRIMITIVE_TOPOLOGY_PATCH_LIST",
+            "primitiveRestartEnable": "VK_FALSE"
+        })";
+            break;
+    }
+
+    ChainPNext(ci, json, pNext);
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkPipelineTessellationStateCreateInfo, std::string> getVkPipelineTessellationStateCreateInfo(
+    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkPipelineTessellationStateCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    switch (seed % 2) {
+        default:
+            ci.patchControlPoints = 4;
+            json = R"({
+            "sType": "VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO",
+            "pNext": "NULL",
+            "flags": 0,
+            "patchControlPoints": 4
+        })";
+            break;
+    }
+
+    ChainPNext(ci, json, pNext);
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkPipelineViewportStateCreateInfo, std::string> getVkPipelineViewportStateCreateInfo(
+    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkPipelineViewportStateCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    switch (seed % 2) {
+        default:
+            VkViewport viewports[1] = {{0.f, 0.f, 51.f, 51.f, 0.f, 1.f}};
+            VkRect2D scissors[1] = {{VkOffset2D{0, 0}, VkExtent2D{51, 51}}};
+            ci.viewportCount = 1;
+            ci.pViewports = viewports;
+            ci.scissorCount = 1;
+            ci.pScissors = scissors;
+            json = R"({
+            "sType": "VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO",
+            "pNext": "NULL",
+            "flags": 0,
+            "viewportCount": 1,
+            "pViewports":
+            [
+                {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "width": 51.0,
+                    "height": 51.0,
+                    "minDepth": 0.0,
+                    "maxDepth": 1.0
+                }
+            ],
+            "scissorCount": 1,
+            "pScissors":
+            [
+                {
+                    "offset":
+                    {
+                        "x": 0,
+                        "y": 0
+                    },
+                    "extent":
+                    {
+                        "width": 51,
+                        "height": 51
+                    }
+                }
+            ]
+        })";
+            break;
+    }
+
+    ChainPNext(ci, json, pNext);
+
+    return {vku::safe_VkPipelineViewportStateCreateInfo{&ci, false, false}, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkPipelineRasterizationStateCreateInfo, std::string> getVkPipelineRasterizationStateCreateInfo(
+    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkPipelineRasterizationStateCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    switch (seed % 2) {
+        default:
+            ci.depthClampEnable = VK_FALSE;
+            ci.rasterizerDiscardEnable = VK_FALSE;
+            ci.polygonMode = VK_POLYGON_MODE_FILL;
+            ci.cullMode = 0;
+            ci.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+            ci.depthBiasEnable = VK_FALSE;
+            ci.depthBiasConstantFactor = 0.f;
+            ci.depthBiasClamp = 0.f;
+            ci.depthBiasSlopeFactor = 0.f;
+            ci.lineWidth = 1.f;
+            json = R"({
+            "sType": "VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO",
+            "pNext": "NULL",
+            "flags": 0,
+            "depthClampEnable": "VK_FALSE",
+            "rasterizerDiscardEnable": "VK_FALSE",
+            "polygonMode": "VK_POLYGON_MODE_FILL",
+            "cullMode": 0,
+            "frontFace": "VK_FRONT_FACE_COUNTER_CLOCKWISE",
+            "depthBiasEnable": "VK_FALSE",
+            "depthBiasConstantFactor": 0.0,
+            "depthBiasClamp": 0.0,
+            "depthBiasSlopeFactor": 0.0,
+            "lineWidth": 1.0
+        })";
+            break;
+    }
+
+    ChainPNext(ci, json, pNext);
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkPipelineMultisampleStateCreateInfo, std::string> getVkPipelineMultisampleStateCreateInfo(
+    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkPipelineMultisampleStateCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    switch (seed % 2) {
+        default:
+            ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+            ci.sampleShadingEnable = VK_FALSE;
+            ci.minSampleShading = 1.f;
+            ci.pSampleMask = nullptr;
+            ci.alphaToCoverageEnable = VK_FALSE;
+            ci.alphaToOneEnable = VK_FALSE;
+            json = R"({
+            "sType": "VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO",
+            "pNext": "NULL",
+            "flags": 0,
+            "rasterizationSamples": "VK_SAMPLE_COUNT_1_BIT",
+            "sampleShadingEnable": "VK_FALSE",
+            "minSampleShading": 1.0,
+            "pSampleMask": "NULL",
+            "alphaToCoverageEnable": "VK_FALSE",
+            "alphaToOneEnable": "VK_FALSE"
+        })";
+            break;
+    }
+
+    ChainPNext(ci, json, pNext);
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkPipelineDepthStencilStateCreateInfo, std::string> getVkPipelineDepthStencilStateCreateInfo(
+    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkPipelineDepthStencilStateCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    switch (seed % 2) {
+        default:
+            ci.depthTestEnable = VK_TRUE;
+            ci.depthWriteEnable = VK_TRUE;
+            ci.depthCompareOp = VK_COMPARE_OP_LESS_OR_EQUAL;
+            ci.depthBoundsTestEnable = VK_FALSE;
+            ci.stencilTestEnable = VK_FALSE;
+            ci.front.failOp = VK_STENCIL_OP_INVERT;
+            ci.front.passOp = VK_STENCIL_OP_KEEP;
+            ci.front.depthFailOp = VK_STENCIL_OP_ZERO;
+            ci.front.compareOp = VK_COMPARE_OP_NEVER;
+            ci.front.compareMask = 0;
+            ci.front.writeMask = 0;
+            ci.front.reference = 0;
+            ci.back.failOp = VK_STENCIL_OP_INVERT;
+            ci.back.passOp = VK_STENCIL_OP_KEEP;
+            ci.back.depthFailOp = VK_STENCIL_OP_ZERO;
+            ci.back.compareOp = VK_COMPARE_OP_NEVER;
+            ci.back.compareMask = 0;
+            ci.back.writeMask = 0;
+            ci.back.reference = 0;
+            ci.minDepthBounds = 0.f;
+            ci.maxDepthBounds = 1.f;
+            json = R"({
+            "sType": "VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO",
+            "pNext": "NULL",
+            "flags": 0,
+            "depthTestEnable": "VK_TRUE",
+            "depthWriteEnable": "VK_TRUE",
+            "depthCompareOp": "VK_COMPARE_OP_LESS_OR_EQUAL",
+            "depthBoundsTestEnable": "VK_FALSE",
+            "stencilTestEnable": "VK_FALSE",
+            "front":
+            {
+                "failOp": "VK_STENCIL_OP_INVERT",
+                "passOp": "VK_STENCIL_OP_KEEP",
+                "depthFailOp": "VK_STENCIL_OP_ZERO",
+                "compareOp": "VK_COMPARE_OP_NEVER",
+                "compareMask": 0,
+                "writeMask": 0,
+                "reference": 0
+            },
+            "back":
+            {
+                "failOp": "VK_STENCIL_OP_INVERT",
+                "passOp": "VK_STENCIL_OP_KEEP",
+                "depthFailOp": "VK_STENCIL_OP_ZERO",
+                "compareOp": "VK_COMPARE_OP_NEVER",
+                "compareMask": 0,
+                "writeMask": 0,
+                "reference": 0
+            },
+            "minDepthBounds": 0.0,
+            "maxDepthBounds": 1.0
+        })";
+            break;
+    }
+
+    ChainPNext(ci, json, pNext);
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkPipelineColorBlendStateCreateInfo, std::string> getVkPipelineColorBlendStateCreateInfo(
+    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkPipelineColorBlendStateCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    switch (seed % 2) {
+        default:
+            VkPipelineColorBlendAttachmentState attachments[1] = {
+                {VK_FALSE, VK_BLEND_FACTOR_ZERO, VK_BLEND_FACTOR_ZERO, VK_BLEND_OP_ADD, VK_BLEND_FACTOR_ZERO, VK_BLEND_FACTOR_ZERO,
+                 VK_BLEND_OP_ADD,
+                 VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT}};
+            ci.logicOpEnable = VK_FALSE;
+            ci.logicOp = VK_LOGIC_OP_CLEAR;
+            ci.attachmentCount = 1;
+            ci.pAttachments = attachments;
+            ci.blendConstants[0] = 0.f;
+            ci.blendConstants[1] = 0.f;
+            ci.blendConstants[2] = 0.f;
+            ci.blendConstants[3] = 0.f;
+            json = R"({
+            "sType": "VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO",
+            "pNext": "NULL",
+            "flags": 0,
+            "logicOpEnable": "VK_FALSE",
+            "logicOp": "VK_LOGIC_OP_CLEAR",
+            "attachmentCount": 1,
+            "pAttachments":
+            [
+                {
+                    "blendEnable": "VK_FALSE",
+                    "srcColorBlendFactor": "VK_BLEND_FACTOR_ZERO",
+                    "dstColorBlendFactor": "VK_BLEND_FACTOR_ZERO",
+                    "colorBlendOp": "VK_BLEND_OP_ADD",
+                    "srcAlphaBlendFactor": "VK_BLEND_FACTOR_ZERO",
+                    "dstAlphaBlendFactor": "VK_BLEND_FACTOR_ZERO",
+                    "alphaBlendOp": "VK_BLEND_OP_ADD",
+                    "colorWriteMask": "VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT"
+                }
+            ],
+            "blendConstants": [0.0, 0.0, 0.0, 0.0]
+        })";
+            break;
+    }
+
+    ChainPNext(ci, json, pNext);
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkPipelineDynamicStateCreateInfo, std::string> getVkPipelineDynamicStateCreateInfo(
+    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkPipelineDynamicStateCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    switch (seed % 2) {
+        default:
+            VkDynamicState dynamicStates[1] = {VK_DYNAMIC_STATE_LINE_WIDTH};
+            ci.dynamicStateCount = 1;
+            ci.pDynamicStates = dynamicStates;
+            json = R"({
+            "sType": "VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO",
+            "pNext": "NULL",
+            "flags": 0,
+            "dynamicStateCount": 1,
+            "pDynamicStates": ["VK_DYNAMIC_STATE_LINE_WIDTH"]
+        })";
+            break;
+    }
+
+    ChainPNext(ci, json, pNext);
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkPipelineDiscardRectangleStateCreateInfoEXT, std::string> getVkPipelineDiscardRectangleStateCreateInfoEXT(
+    uint32_t seed = 0) {
+    using namespace std::string_literals;
+
+    VkPipelineDiscardRectangleStateCreateInfoEXT ci = vku::InitStructHelper();
+    std::string json{};
+
+    ci.sType = VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT;
+    ci.pNext = nullptr;
+    ci.flags = 0;
+    VkRect2D discardRectangles{};
+    switch (seed % 2) {
+        default:
+            discardRectangles = {VkOffset2D{0, 0}, VkExtent2D{51, 51}};
+            ci.discardRectangleMode = VK_DISCARD_RECTANGLE_MODE_EXCLUSIVE_EXT;
+            ci.discardRectangleCount = 1;
+            ci.pDiscardRectangles = &discardRectangles;
+            json = R"({
+            "sType": "VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT",
+            "pNext" : "NULL",
+            "flags": 0,
+            "discardRectangleMode": "VK_DISCARD_RECTANGLE_MODE_EXCLUSIVE_EXT",
+            "discardRectangleCount": 1,
+            "pDiscardRectangles": [
+                {
+                    "offset":
+                    {
+                        "x" : 0,
+                        "y" : 0
+                    },
+                    "extent":
+                    {
+                        "width" : 51,
+                        "height" : 51
+                    }
+                }
+            ]
+        })";
+            break;
+    }
+
+    return {&ci, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkGraphicsPipelineCreateInfo, std::string> getVkGraphicsPipelineCreateInfo(
+    uint32_t seed = 0,
+    std::initializer_list<std::pair<vku::safe_VkPipelineShaderStageCreateInfo, std::string>> stages =
+        {getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_VERTEX_BIT),
+         getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_FRAGMENT_BIT)},
+    std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkGraphicsPipelineCreateInfo ci = vku::InitStructHelper();
+    std::string json{};
+
+    std::vector<vku::safe_VkPipelineShaderStageCreateInfo> pStages;
+    std::string pStages_str{};
+    pStages_str = "[";
+    for (auto it = stages.begin(); it != stages.end(); ++it) {
+        pStages.push_back(it->first);
+        pStages_str += it->second;
+        if (std::next(it) != stages.end()) {
+            pStages_str += ",";
+        }
+    }
+    bool has_tessellation_stage = false;
+    for (size_t i = 0; i < pStages.size(); ++i) {
+        if (pStages[i].stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT ||
+            pStages[i].stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT)
+            has_tessellation_stage = true;
+    }
+    pStages_str += "]";
+    auto [pvis_ci, pvis_json] = getVkPipelineVertexInputStateCreateInfo(seed);
+    auto [pias_ci, pias_json] = getVkPipelineInputAssemblyStateCreateInfo(seed);
+    auto [pts_ci, pts_json] = getVkPipelineTessellationStateCreateInfo(seed);
+    auto [pvs_ci, pvs_json] = getVkPipelineViewportStateCreateInfo(seed);
+    auto [prs_ci, prs_json] = getVkPipelineRasterizationStateCreateInfo(seed);
+    auto [pmss_ci, pmss_json] = getVkPipelineMultisampleStateCreateInfo(seed);
+    auto [pdss_ci, pdss_json] = getVkPipelineDepthStencilStateCreateInfo(seed);
+    auto [pcbs_ci, pcbs_json] = getVkPipelineColorBlendStateCreateInfo(seed);
+    auto [pds_ci, pds_json] = getVkPipelineDynamicStateCreateInfo(seed);
+
+    ci.stageCount = (uint32_t)pStages.size();
+    ci.pStages = reinterpret_cast<const VkPipelineShaderStageCreateInfo*>(pStages.data());
+    ci.pVertexInputState = pvis_ci.ptr();
+    ci.pInputAssemblyState = pias_ci.ptr();
+    ci.pTessellationState = has_tessellation_stage ? pts_ci.ptr() : nullptr;
+    ci.pViewportState = pvs_ci.ptr();
+    ci.pRasterizationState = prs_ci.ptr();
+    ci.pMultisampleState = pmss_ci.ptr();
+    ci.pDepthStencilState = pdss_ci.ptr();
+    ci.pColorBlendState = pcbs_ci.ptr();
+    ci.pDynamicState = pds_ci.ptr();
+
+    json = R"({
+        "sType": "VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO",
+        "pNext": "NULL",
+        "flags": 0,
+        "stageCount": )" +
+           std::to_string(ci.stageCount) + R"(,
+        "pStages": )" +
+           pStages_str + R"(,
+        "pVertexInputState": )" +
+           pvis_json + R"(,
+        "pInputAssemblyState": )" +
+           pias_json + R"(,
+        "pTessellationState": )" +
+           (has_tessellation_stage ? pts_json : R"("NULL")"s) + R"(,
+        "pViewportState": )" +
+           pvs_json + R"(,
+        "pRasterizationState": )" +
+           prs_json + R"(,
+        "pMultisampleState": )" +
+           pmss_json + R"(,
+        "pDepthStencilState": )" +
+           pdss_json + R"(,
+        "pColorBlendState": )" +
+           pcbs_json + R"(,
+        "pDynamicState": )" +
+           pds_json + R"(,
+        "layout": "",
+        "renderPass": "",
+        "subpass": 0,
+        "basePipelineHandle" : "",
+        "basePipelineIndex" : 0,
+    })";
+
+    ChainPNext(ci, json, pNext);
+
+    return {vku::safe_VkGraphicsPipelineCreateInfo{&ci, true, true}, json};
+}
+
+std::pair<vku::safe_VkPhysicalDeviceSynchronization2Features, std::string> getVkPhysicalDeviceSynchronization2Features() {
+    using namespace std::string_literals;
+
+    VkPhysicalDeviceSynchronization2Features pdf = vku::InitStructHelper();
+    std::string json{};
+
+    pdf.synchronization2 = VK_TRUE;
+
+    json = R"({
+        "sType": "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES",
+        "pNext": "NULL",
+        "synchronization2": "VK_TRUE"
+    })";
+
+    return {&pdf, json};
+}
+
+std::pair<vku::safe_VkPhysicalDeviceScalarBlockLayoutFeatures, std::string> getVkPhysicalDeviceScalarBlockLayoutFeatures() {
+    using namespace std::string_literals;
+
+    VkPhysicalDeviceScalarBlockLayoutFeatures pdsblf = vku::InitStructHelper();
+    std::string json{};
+
+    pdsblf.scalarBlockLayout = VK_TRUE;
+
+    json = R"({
+        "sType": "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES",
+        "pNext": "NULL",
+        "scalarBlockLayout": "VK_TRUE"
+    })";
+
+    return {&pdsblf, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkPhysicalDeviceVulkan11Features, std::string> getVkPhysicalDeviceVulkan11Features(uint32_t seed = 0) {
+    using namespace std::string_literals;
+
+    VkPhysicalDeviceVulkan11Features pdf = vku::InitStructHelper();
+    std::string json{};
+
+    std::string features_str = R"(
+        "storageBuffer16BitAccess" : "VK_FALSE",
+        "uniformAndStorageBuffer16BitAccess" : "VK_FALSE",
+        "storagePushConstant16" : "VK_FALSE",
+        "storageInputOutput16" : "VK_FALSE",
+        "multiview" : "VK_FALSE",
+        "multiviewGeometryShader" : "VK_FALSE",
+        "multiviewTessellationShader" : "VK_FALSE",
+        "variablePointersStorageBuffer" : "VK_FALSE",
+        "variablePointers" : "VK_FALSE",
+        "protectedMemory" : "VK_FALSE",
+        "samplerYcbcrConversion" : "VK_FALSE",
+        "shaderDrawParameters" : "VK_FALSE"
+    )";
+    auto change_to_true = [&](std::string_view feature) {
+        std::string false_snippet = R"(")"s + feature.data() + R"(" : "VK_FALSE")";
+        std::string true_snippet = R"(")"s + feature.data() + R"(" : "VK_TRUE")";
+        features_str.replace(features_str.find(false_snippet), false_snippet.length(), true_snippet);
+    };
+    switch (seed % 2) {
+        case 0:
+            pdf.samplerYcbcrConversion = VK_TRUE;
+            change_to_true("samplerYcbcrConversion");
+            break;
+        case 1:
+            pdf.multiview = VK_TRUE;
+            change_to_true("multiview");
+            break;
+    }
+
+    json = R"({
+        "sType": "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES",
+        "pNext": "NULL",
+        )"s +
+           features_str + R"(
+    })";
+
+    return {&pdf, json};
+}
+
+template <typename... InStructure>
+std::pair<vku::safe_VkPhysicalDeviceFeatures2, std::string> getVkPhysicalDeviceFeatures2(
+    uint32_t seed = 0, std::tuple<std::pair<InStructure, std::string>...> pNext = std::tuple<>{}) {
+    using namespace std::string_literals;
+
+    VkPhysicalDeviceFeatures2 pdf = vku::InitStructHelper();
+    std::string json{};
+
+    std::string features_str = R"({
+        "alphaToOne" : "VK_FALSE",
+        "depthBiasClamp" : "VK_FALSE",
+        "depthBounds" : "VK_FALSE",
+        "depthClamp" : "VK_FALSE",
+        "drawIndirectFirstInstance" : "VK_FALSE",
+        "dualSrcBlend" : "VK_FALSE",
+        "fillModeNonSolid" : "VK_FALSE",
+        "fragmentStoresAndAtomics" : "VK_FALSE",
+        "fullDrawIndexUint32" : "VK_FALSE",
+        "geometryShader" : "VK_FALSE",
+        "imageCubeArray" : "VK_FALSE",
+        "independentBlend" : "VK_FALSE",
+        "inheritedQueries" : "VK_FALSE",
+        "largePoints" : "VK_FALSE",
+        "logicOp" : "VK_FALSE",
+        "multiDrawIndirect" : "VK_FALSE",
+        "multiViewport" : "VK_FALSE",
+        "occlusionQueryPrecise" : "VK_FALSE",
+        "pipelineStatisticsQuery" : "VK_FALSE",
+        "robustBufferAccess" : "VK_FALSE",
+        "sampleRateShading" : "VK_FALSE",
+        "samplerAnisotropy" : "VK_FALSE",
+        "shaderClipDistance" : "VK_FALSE",
+        "shaderCullDistance" : "VK_FALSE",
+        "shaderFloat64" : "VK_FALSE",
+        "shaderImageGatherExtended" : "VK_FALSE",
+        "shaderInt16" : "VK_FALSE",
+        "shaderInt64" : "VK_FALSE",
+        "shaderResourceMinLod" : "VK_FALSE",
+        "shaderResourceResidency" : "VK_FALSE",
+        "shaderSampledImageArrayDynamicIndexing" : "VK_FALSE",
+        "shaderStorageBufferArrayDynamicIndexing" : "VK_FALSE",
+        "shaderStorageImageArrayDynamicIndexing" : "VK_FALSE",
+        "shaderStorageImageExtendedFormats" : "VK_FALSE",
+        "shaderStorageImageMultisample" : "VK_FALSE",
+        "shaderStorageImageReadWithoutFormat" : "VK_FALSE",
+        "shaderStorageImageWriteWithoutFormat" : "VK_FALSE",
+        "shaderTessellationAndGeometryPointSize" : "VK_FALSE",
+        "shaderUniformBufferArrayDynamicIndexing" : "VK_FALSE",
+        "sparseBinding" : "VK_FALSE",
+        "sparseResidency16Samples" : "VK_FALSE",
+        "sparseResidency2Samples" : "VK_FALSE",
+        "sparseResidency4Samples" : "VK_FALSE",
+        "sparseResidency8Samples" : "VK_FALSE",
+        "sparseResidencyAliased" : "VK_FALSE",
+        "sparseResidencyBuffer" : "VK_FALSE",
+        "sparseResidencyImage2D" : "VK_FALSE",
+        "sparseResidencyImage3D" : "VK_FALSE",
+        "tessellationShader" : "VK_FALSE",
+        "textureCompressionASTC_LDR" : "VK_FALSE",
+        "textureCompressionBC" : "VK_FALSE",
+        "textureCompressionETC2" : "VK_FALSE",
+        "variableMultisampleRate" : "VK_FALSE",
+        "vertexPipelineStoresAndAtomics" : "VK_FALSE",
+        "wideLines" : "VK_FALSE"
+    })";
+    auto change_to_true = [&](std::string_view feature) {
+        std::string false_snippet = R"(")"s + feature.data() + R"(" : "VK_FALSE")";
+        std::string true_snippet = R"(")"s + feature.data() + R"(" : "VK_TRUE")";
+        features_str.replace(features_str.find(false_snippet), false_snippet.length(), true_snippet);
+    };
+    switch (seed % 3) {
+        case 0:
+            pdf.features.robustBufferAccess = VK_TRUE;
+            change_to_true("robustBufferAccess");
+            break;
+        case 1:
+            pdf.features.sparseBinding = VK_TRUE;
+            change_to_true("sparseBinding");
+            break;
+        case 2:
+            pdf.features.wideLines = VK_TRUE;
+            change_to_true("wideLines");
+            break;
+    }
+
+    json = R"({
+        "sType": "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2",
+        "pNext": "NULL",
+        "features": )"s +
+           features_str + R"(
+    })";
+
+    ChainPNext(pdf, json, pNext);
+
+    return {&pdf, json};
+}
+
+// NOTE: It is known that VpjShaderFileName holds it's members in a non-owning manner. In the absence of
+// safe_VpjShaderFilename This utility only works with pFilename and pCode kept alive by the caller
+// (literal or otherwise).
+std::pair<std::vector<VpjShaderFileName>, std::string> getShaderFileNames(
+    std::initializer_list<VpjShaderFileName> shader_filenames = {}) {
+    using namespace std::string_literals;
+
+    std::vector<VpjShaderFileName> shaderFilenames(shader_filenames);
+    std::string json{};
+
+    json = "[";
+    for (auto it = shaderFilenames.begin(); it != shaderFilenames.end(); ++it) {
+        json += R"({
+            "filename" : ")"s +
+                it->pFilename + R"(",
+            "stage" : ")" +
+                shader_stage_flag_to_string(it->stage) + R"("})";
+        if (std::next(it) != shaderFilenames.end()) {
+            json += ",";
+        }
+    }
+    json += "]";
+
+    return {shaderFilenames, json};
+}
+
+void CompareStruct(const vku::safe_VkPhysicalDeviceSynchronization2Features& ref,
+                   const VkPhysicalDeviceSynchronization2Features& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    EXPECT_EQ(ref.synchronization2, res.synchronization2);
+}
+
+void CompareStruct(const vku::safe_VkPhysicalDeviceVulkan11Features& ref, const VkPhysicalDeviceVulkan11Features& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    EXPECT_EQ(ref.storageBuffer16BitAccess, res.storageBuffer16BitAccess);
+    EXPECT_EQ(ref.uniformAndStorageBuffer16BitAccess, res.uniformAndStorageBuffer16BitAccess);
+    EXPECT_EQ(ref.storagePushConstant16, res.storagePushConstant16);
+    EXPECT_EQ(ref.storageInputOutput16, res.storageInputOutput16);
+    EXPECT_EQ(ref.multiview, res.multiview);
+    EXPECT_EQ(ref.multiviewGeometryShader, res.multiviewGeometryShader);
+    EXPECT_EQ(ref.multiviewTessellationShader, res.multiviewTessellationShader);
+    EXPECT_EQ(ref.variablePointersStorageBuffer, res.variablePointersStorageBuffer);
+    EXPECT_EQ(ref.variablePointers, res.variablePointers);
+    EXPECT_EQ(ref.protectedMemory, res.protectedMemory);
+    EXPECT_EQ(ref.samplerYcbcrConversion, res.samplerYcbcrConversion);
+    EXPECT_EQ(ref.shaderDrawParameters, res.shaderDrawParameters);
+}
+
+void CompareStruct(const vku::safe_VkPhysicalDeviceScalarBlockLayoutFeatures& ref,
+                   const VkPhysicalDeviceScalarBlockLayoutFeatures& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    EXPECT_EQ(ref.scalarBlockLayout, res.scalarBlockLayout);
+}
+
+void CompareStruct(const vku::safe_VkPhysicalDeviceFeatures2& ref, const VkPhysicalDeviceFeatures2& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES:
+                CompareStruct(*reinterpret_cast<const vku::safe_VkPhysicalDeviceSynchronization2Features*>(ref_pNext),
+                              *reinterpret_cast<const VkPhysicalDeviceSynchronization2Features*>(res_pNext));
+                break;
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES:
+                CompareStruct(*reinterpret_cast<const vku::safe_VkPhysicalDeviceVulkan11Features*>(ref_pNext),
+                              *reinterpret_cast<const VkPhysicalDeviceVulkan11Features*>(res_pNext));
+                break;
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES:
+                CompareStruct(*reinterpret_cast<const vku::safe_VkPhysicalDeviceScalarBlockLayoutFeatures*>(ref_pNext),
+                              *reinterpret_cast<const VkPhysicalDeviceScalarBlockLayoutFeatures*>(res_pNext));
+                break;
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.features.robustBufferAccess, res.features.robustBufferAccess);
+    EXPECT_EQ(ref.features.fullDrawIndexUint32, res.features.fullDrawIndexUint32);
+    EXPECT_EQ(ref.features.imageCubeArray, res.features.imageCubeArray);
+    EXPECT_EQ(ref.features.independentBlend, res.features.independentBlend);
+    EXPECT_EQ(ref.features.geometryShader, res.features.geometryShader);
+    EXPECT_EQ(ref.features.tessellationShader, res.features.tessellationShader);
+    EXPECT_EQ(ref.features.sampleRateShading, res.features.sampleRateShading);
+    EXPECT_EQ(ref.features.dualSrcBlend, res.features.dualSrcBlend);
+    EXPECT_EQ(ref.features.logicOp, res.features.logicOp);
+    EXPECT_EQ(ref.features.multiDrawIndirect, res.features.multiDrawIndirect);
+    EXPECT_EQ(ref.features.drawIndirectFirstInstance, res.features.drawIndirectFirstInstance);
+    EXPECT_EQ(ref.features.depthClamp, res.features.depthClamp);
+    EXPECT_EQ(ref.features.depthBiasClamp, res.features.depthBiasClamp);
+    EXPECT_EQ(ref.features.fillModeNonSolid, res.features.fillModeNonSolid);
+    EXPECT_EQ(ref.features.depthBounds, res.features.depthBounds);
+    EXPECT_EQ(ref.features.wideLines, res.features.wideLines);
+    EXPECT_EQ(ref.features.largePoints, res.features.largePoints);
+    EXPECT_EQ(ref.features.alphaToOne, res.features.alphaToOne);
+    EXPECT_EQ(ref.features.multiViewport, res.features.multiViewport);
+    EXPECT_EQ(ref.features.samplerAnisotropy, res.features.samplerAnisotropy);
+    EXPECT_EQ(ref.features.textureCompressionETC2, res.features.textureCompressionETC2);
+    EXPECT_EQ(ref.features.textureCompressionASTC_LDR, res.features.textureCompressionASTC_LDR);
+    EXPECT_EQ(ref.features.textureCompressionBC, res.features.textureCompressionBC);
+    EXPECT_EQ(ref.features.occlusionQueryPrecise, res.features.occlusionQueryPrecise);
+    EXPECT_EQ(ref.features.pipelineStatisticsQuery, res.features.pipelineStatisticsQuery);
+    EXPECT_EQ(ref.features.vertexPipelineStoresAndAtomics, res.features.vertexPipelineStoresAndAtomics);
+    EXPECT_EQ(ref.features.fragmentStoresAndAtomics, res.features.fragmentStoresAndAtomics);
+    EXPECT_EQ(ref.features.shaderTessellationAndGeometryPointSize, res.features.shaderTessellationAndGeometryPointSize);
+    EXPECT_EQ(ref.features.shaderImageGatherExtended, res.features.shaderImageGatherExtended);
+    EXPECT_EQ(ref.features.shaderStorageImageExtendedFormats, res.features.shaderStorageImageExtendedFormats);
+    EXPECT_EQ(ref.features.shaderStorageImageMultisample, res.features.shaderStorageImageMultisample);
+    EXPECT_EQ(ref.features.shaderStorageImageReadWithoutFormat, res.features.shaderStorageImageReadWithoutFormat);
+    EXPECT_EQ(ref.features.shaderStorageImageWriteWithoutFormat, res.features.shaderStorageImageWriteWithoutFormat);
+    EXPECT_EQ(ref.features.shaderUniformBufferArrayDynamicIndexing, res.features.shaderUniformBufferArrayDynamicIndexing);
+    EXPECT_EQ(ref.features.shaderSampledImageArrayDynamicIndexing, res.features.shaderSampledImageArrayDynamicIndexing);
+    EXPECT_EQ(ref.features.shaderStorageBufferArrayDynamicIndexing, res.features.shaderStorageBufferArrayDynamicIndexing);
+    EXPECT_EQ(ref.features.shaderStorageImageArrayDynamicIndexing, res.features.shaderStorageImageArrayDynamicIndexing);
+    EXPECT_EQ(ref.features.shaderClipDistance, res.features.shaderClipDistance);
+    EXPECT_EQ(ref.features.shaderCullDistance, res.features.shaderCullDistance);
+    EXPECT_EQ(ref.features.shaderFloat64, res.features.shaderFloat64);
+    EXPECT_EQ(ref.features.shaderInt64, res.features.shaderInt64);
+    EXPECT_EQ(ref.features.shaderInt16, res.features.shaderInt16);
+    EXPECT_EQ(ref.features.shaderResourceResidency, res.features.shaderResourceResidency);
+    EXPECT_EQ(ref.features.shaderResourceMinLod, res.features.shaderResourceMinLod);
+    EXPECT_EQ(ref.features.sparseBinding, res.features.sparseBinding);
+    EXPECT_EQ(ref.features.sparseResidencyBuffer, res.features.sparseResidencyBuffer);
+    EXPECT_EQ(ref.features.sparseResidencyImage2D, res.features.sparseResidencyImage2D);
+    EXPECT_EQ(ref.features.sparseResidencyImage3D, res.features.sparseResidencyImage3D);
+    EXPECT_EQ(ref.features.sparseResidency2Samples, res.features.sparseResidency2Samples);
+    EXPECT_EQ(ref.features.sparseResidency4Samples, res.features.sparseResidency4Samples);
+    EXPECT_EQ(ref.features.sparseResidency8Samples, res.features.sparseResidency8Samples);
+    EXPECT_EQ(ref.features.sparseResidency16Samples, res.features.sparseResidency16Samples);
+    EXPECT_EQ(ref.features.sparseResidencyAliased, res.features.sparseResidencyAliased);
+    EXPECT_EQ(ref.features.variableMultisampleRate, res.features.variableMultisampleRate);
+    EXPECT_EQ(ref.features.inheritedQueries, res.features.inheritedQueries);
+}
+
+void CompareStruct(const vku::safe_VkSamplerYcbcrConversionCreateInfo& ref, const VkSamplerYcbcrConversionCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.format, res.format);
+    EXPECT_EQ(ref.ycbcrModel, res.ycbcrModel);
+    EXPECT_EQ(ref.ycbcrRange, res.ycbcrRange);
+    EXPECT_EQ(ref.components.r, res.components.r);
+    EXPECT_EQ(ref.components.g, res.components.g);
+    EXPECT_EQ(ref.components.b, res.components.b);
+    EXPECT_EQ(ref.components.a, res.components.a);
+    EXPECT_EQ(ref.xChromaOffset, res.xChromaOffset);
+    EXPECT_EQ(ref.yChromaOffset, res.yChromaOffset);
+    EXPECT_EQ(ref.chromaFilter, res.chromaFilter);
+}
+
+void CompareStruct(const vku::safe_VkSamplerYcbcrConversionInfo& ref, const VkSamplerYcbcrConversionInfo& res,
+                   bool has_names = false) {
+    EXPECT_EQ(ref.sType, res.sType);
+    if (!has_names) {
+        EXPECT_EQ(ref.conversion, res.conversion);
+    }
+}
+
+void CompareStruct(const vku::safe_VkSamplerReductionModeCreateInfo& ref, const VkSamplerReductionModeCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    EXPECT_EQ(ref.reductionMode, res.reductionMode);
+}
+
+void CompareStruct(const vku::safe_VkSamplerCreateInfo& ref, const VkSamplerCreateInfo& res, bool has_names = false) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO:
+                CompareStruct(*reinterpret_cast<const vku::safe_VkSamplerYcbcrConversionInfo*>(ref_pNext),
+                              *reinterpret_cast<const VkSamplerYcbcrConversionInfo*>(res_pNext), has_names);
+                break;
+            case VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO:
+                CompareStruct(*reinterpret_cast<const vku::safe_VkSamplerReductionModeCreateInfo*>(ref_pNext),
+                              *reinterpret_cast<const VkSamplerReductionModeCreateInfo*>(res_pNext));
+                break;
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    EXPECT_EQ(ref.magFilter, res.magFilter);
+    EXPECT_EQ(ref.minFilter, res.minFilter);
+    EXPECT_EQ(ref.mipmapMode, res.mipmapMode);
+    EXPECT_EQ(ref.addressModeU, res.addressModeU);
+    EXPECT_EQ(ref.addressModeV, res.addressModeV);
+    EXPECT_EQ(ref.addressModeW, res.addressModeW);
+    EXPECT_EQ(ref.mipLodBias, res.mipLodBias);
+    EXPECT_EQ(ref.anisotropyEnable, res.anisotropyEnable);
+    EXPECT_EQ(ref.maxAnisotropy, res.maxAnisotropy);
+    EXPECT_EQ(ref.compareEnable, res.compareEnable);
+    EXPECT_EQ(ref.compareOp, res.compareOp);
+    if (std::isnan(ref.minLod)) {
+        EXPECT_TRUE(std::isnan(res.minLod));
+    } else {
+        EXPECT_EQ(ref.compareOp, res.compareOp);
+    };
+    EXPECT_EQ(ref.maxLod, res.maxLod);
+    EXPECT_EQ(ref.borderColor, res.borderColor);
+    EXPECT_EQ(ref.unnormalizedCoordinates, res.unnormalizedCoordinates);
+}
+
+void CompareStruct(const vku::safe_VkDescriptorSetLayoutBindingFlagsCreateInfo& ref,
+                   const VkDescriptorSetLayoutBindingFlagsCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    EXPECT_EQ(ref.bindingCount, res.bindingCount);
+    for (uint32_t i = 0; i < ref.bindingCount; ++i) {
+        EXPECT_EQ(ref.pBindingFlags[i], res.pBindingFlags[i]);
+    }
+}
+
+void CompareStruct(const vku::safe_VkDescriptorSetLayoutCreateInfo& ref, const VkDescriptorSetLayoutCreateInfo& res,
+                   bool has_names = false) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO:
+                CompareStruct(*reinterpret_cast<const vku::safe_VkDescriptorSetLayoutBindingFlagsCreateInfo*>(ref_pNext),
+                              *reinterpret_cast<const VkDescriptorSetLayoutBindingFlagsCreateInfo*>(res_pNext));
+                break;
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    EXPECT_EQ(ref.bindingCount, res.bindingCount);
+    for (uint32_t i = 0; i < ref.bindingCount; ++i) {
+        EXPECT_EQ(ref.pBindings[i].binding, res.pBindings[i].binding);
+        EXPECT_EQ(ref.pBindings[i].descriptorType, res.pBindings[i].descriptorType);
+        EXPECT_EQ(ref.pBindings[i].descriptorCount, res.pBindings[i].descriptorCount);
+        EXPECT_EQ(ref.pBindings[i].stageFlags, res.pBindings[i].stageFlags);
+        if (!has_names) {
+            if (ref.pBindings[i].pImmutableSamplers) {
+                EXPECT_EQ(*ref.pBindings[i].pImmutableSamplers, *res.pBindings[i].pImmutableSamplers);
+            } else {
+                EXPECT_EQ(ref.pBindings[i].pImmutableSamplers, res.pBindings[i].pImmutableSamplers);
+            }
+        }
+    }
+}
+
+void CompareStruct(const vku::safe_VkPipelineLayoutCreateInfo& ref, const VkPipelineLayoutCreateInfo& res, bool has_names = false) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    EXPECT_EQ(ref.setLayoutCount, res.setLayoutCount);
+    if (ref.setLayoutCount) {
+        for (uint32_t i = 0; i < ref.setLayoutCount; ++i) {
+            if (!has_names) {
+                EXPECT_EQ(ref.pSetLayouts[i], res.pSetLayouts[i]);
+            }
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pSetLayouts);
+    }
+    EXPECT_EQ(ref.pushConstantRangeCount, res.pushConstantRangeCount);
+    if (ref.pushConstantRangeCount) {
+        for (uint32_t i = 0; i < ref.pushConstantRangeCount; ++i) {
+            EXPECT_EQ(ref.pPushConstantRanges[i].stageFlags, res.pPushConstantRanges[i].stageFlags);
+            EXPECT_EQ(ref.pPushConstantRanges[i].offset, res.pPushConstantRanges[i].offset);
+            EXPECT_EQ(ref.pPushConstantRanges[i].size, res.pPushConstantRanges[i].size);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pPushConstantRanges);
+    }
+}
+
+void CompareStruct(const vku::safe_VkRenderPassInputAttachmentAspectCreateInfo& ref,
+                   const VkRenderPassInputAttachmentAspectCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    EXPECT_EQ(ref.aspectReferenceCount, res.aspectReferenceCount);
+    if (ref.aspectReferenceCount) {
+        for (uint32_t i = 0; i < ref.aspectReferenceCount; ++i) {
+            EXPECT_EQ(ref.pAspectReferences[i].subpass, res.pAspectReferences[i].subpass);
+            EXPECT_EQ(ref.pAspectReferences[i].inputAttachmentIndex, res.pAspectReferences[i].inputAttachmentIndex);
+            EXPECT_EQ(ref.pAspectReferences[i].aspectMask, res.pAspectReferences[i].aspectMask);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pAspectReferences);
+    }
+}
+
+void CompareStruct(const vku::safe_VkRenderPassMultiviewCreateInfo& ref, const VkRenderPassMultiviewCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    EXPECT_EQ(ref.subpassCount, res.subpassCount);
+    if (ref.subpassCount) {
+        for (uint32_t i = 0; i < ref.subpassCount; ++i) {
+            EXPECT_EQ(ref.pViewMasks[i], res.pViewMasks[i]);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pViewMasks);
+    }
+    EXPECT_EQ(ref.dependencyCount, res.dependencyCount);
+    if (ref.dependencyCount) {
+        for (uint32_t i = 0; i < ref.dependencyCount; ++i) {
+            EXPECT_EQ(ref.pViewOffsets[i], res.pViewOffsets[i]);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pViewOffsets);
+    }
+    EXPECT_EQ(ref.correlationMaskCount, res.correlationMaskCount);
+    if (ref.correlationMaskCount) {
+        for (uint32_t i = 0; i < ref.correlationMaskCount; ++i) {
+            EXPECT_EQ(ref.pCorrelationMasks[i], res.pCorrelationMasks[i]);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pCorrelationMasks);
+    }
+}
+
+void CompareStruct(const vku::safe_VkRenderPassCreateInfo& ref, const VkRenderPassCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            case VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO:
+                CompareStruct(*reinterpret_cast<const vku::safe_VkRenderPassInputAttachmentAspectCreateInfo*>(ref_pNext),
+                              *reinterpret_cast<const VkRenderPassInputAttachmentAspectCreateInfo*>(res_pNext));
+                break;
+            case VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO:
+                CompareStruct(*reinterpret_cast<const vku::safe_VkRenderPassMultiviewCreateInfo*>(ref_pNext),
+                              *reinterpret_cast<const VkRenderPassMultiviewCreateInfo*>(res_pNext));
+                break;
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    EXPECT_EQ(ref.attachmentCount, res.attachmentCount);
+    if (ref.attachmentCount) {
+        for (uint32_t i = 0; i < ref.attachmentCount; ++i) {
+            EXPECT_EQ(ref.pAttachments[i].flags, res.pAttachments[i].flags);
+            EXPECT_EQ(ref.pAttachments[i].format, res.pAttachments[i].format);
+            EXPECT_EQ(ref.pAttachments[i].samples, res.pAttachments[i].samples);
+            EXPECT_EQ(ref.pAttachments[i].loadOp, res.pAttachments[i].loadOp);
+            EXPECT_EQ(ref.pAttachments[i].storeOp, res.pAttachments[i].storeOp);
+            EXPECT_EQ(ref.pAttachments[i].stencilLoadOp, res.pAttachments[i].stencilLoadOp);
+            EXPECT_EQ(ref.pAttachments[i].stencilStoreOp, res.pAttachments[i].stencilStoreOp);
+            EXPECT_EQ(ref.pAttachments[i].initialLayout, res.pAttachments[i].initialLayout);
+            EXPECT_EQ(ref.pAttachments[i].finalLayout, res.pAttachments[i].finalLayout);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pAttachments);
+    }
+    EXPECT_EQ(ref.subpassCount, res.subpassCount);
+    if (ref.subpassCount) {
+        for (uint32_t i = 0; i < ref.subpassCount; ++i) {
+            EXPECT_EQ(ref.pSubpasses[i].flags, res.pSubpasses[i].flags);
+            EXPECT_EQ(ref.pSubpasses[i].pipelineBindPoint, res.pSubpasses[i].pipelineBindPoint);
+            EXPECT_EQ(ref.pSubpasses[i].inputAttachmentCount, res.pSubpasses[i].inputAttachmentCount);
+            if (ref.pSubpasses[i].inputAttachmentCount) {
+                for (uint32_t j = 0; j < ref.pSubpasses[i].inputAttachmentCount; ++j) {
+                    EXPECT_EQ(ref.pSubpasses[i].pInputAttachments[j].attachment, res.pSubpasses[i].pInputAttachments[j].attachment);
+                    EXPECT_EQ(ref.pSubpasses[i].pInputAttachments[j].layout, res.pSubpasses[i].pInputAttachments[j].layout);
+                }
+            } else {
+                EXPECT_EQ(nullptr, res.pSubpasses[i].pInputAttachments);
+            }
+            EXPECT_EQ(ref.pSubpasses[i].colorAttachmentCount, res.pSubpasses[i].colorAttachmentCount);
+            if (ref.pSubpasses[i].colorAttachmentCount) {
+                for (uint32_t j = 0; j < ref.pSubpasses[i].colorAttachmentCount; ++j) {
+                    EXPECT_EQ(ref.pSubpasses[i].pColorAttachments[j].attachment, res.pSubpasses[i].pColorAttachments[j].attachment);
+                    EXPECT_EQ(ref.pSubpasses[i].pColorAttachments[j].layout, res.pSubpasses[i].pColorAttachments[j].layout);
+                }
+            } else {
+                EXPECT_EQ(nullptr, res.pSubpasses[i].pColorAttachments);
+            }
+            if (ref.pSubpasses[i].pResolveAttachments) {
+                for (uint32_t j = 0; j < ref.pSubpasses[i].colorAttachmentCount; ++j) {
+                    EXPECT_EQ(ref.pSubpasses[i].pResolveAttachments[j].attachment,
+                              res.pSubpasses[i].pResolveAttachments[j].attachment);
+                    EXPECT_EQ(ref.pSubpasses[i].pResolveAttachments[j].layout, res.pSubpasses[i].pResolveAttachments[j].layout);
+                }
+            } else {
+                EXPECT_EQ(nullptr, res.pSubpasses[i].pResolveAttachments);
+            }
+            if (ref.pSubpasses[i].pDepthStencilAttachment) {
+                for (uint32_t j = 0; j < ref.pSubpasses[i].colorAttachmentCount; ++j) {
+                    EXPECT_EQ(ref.pSubpasses[i].pDepthStencilAttachment[j].attachment,
+                              res.pSubpasses[i].pDepthStencilAttachment[j].attachment);
+                    EXPECT_EQ(ref.pSubpasses[i].pDepthStencilAttachment[j].layout,
+                              res.pSubpasses[i].pDepthStencilAttachment[j].layout);
+                }
+            } else {
+                EXPECT_EQ(nullptr, res.pSubpasses[i].pDepthStencilAttachment);
+            }
+            if (ref.pSubpasses[i].pPreserveAttachments) {
+                for (uint32_t j = 0; j < ref.pSubpasses[i].colorAttachmentCount; ++j) {
+                    EXPECT_EQ(ref.pSubpasses[i].pPreserveAttachments[j], res.pSubpasses[i].pPreserveAttachments[j]);
+                }
+            } else {
+                EXPECT_EQ(nullptr, res.pSubpasses[i].pPreserveAttachments);
+            }
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pSubpasses);
+    }
+    EXPECT_EQ(ref.dependencyCount, res.dependencyCount);
+    if (ref.dependencyCount) {
+        for (uint32_t i = 0; i < ref.dependencyCount; ++i) {
+            EXPECT_EQ(ref.pDependencies[i].srcSubpass, res.pDependencies[i].srcSubpass);
+            EXPECT_EQ(ref.pDependencies[i].dstSubpass, res.pDependencies[i].dstSubpass);
+            EXPECT_EQ(ref.pDependencies[i].srcStageMask, res.pDependencies[i].srcStageMask);
+            EXPECT_EQ(ref.pDependencies[i].dstStageMask, res.pDependencies[i].dstStageMask);
+            EXPECT_EQ(ref.pDependencies[i].srcAccessMask, res.pDependencies[i].srcAccessMask);
+            EXPECT_EQ(ref.pDependencies[i].dstAccessMask, res.pDependencies[i].dstAccessMask);
+            EXPECT_EQ(ref.pDependencies[i].dependencyFlags, res.pDependencies[i].dependencyFlags);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pDependencies);
+    }
+}
+
+void CompareStruct(const vku::safe_VkAttachmentDescriptionStencilLayout& ref, const VkAttachmentDescriptionStencilLayout& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    EXPECT_EQ(ref.stencilInitialLayout, res.stencilInitialLayout);
+    EXPECT_EQ(ref.stencilFinalLayout, res.stencilFinalLayout);
+}
+
+void CompareStruct(const vku::safe_VkAttachmentDescription2& ref, const VkAttachmentDescription2& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            case VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT:
+                CompareStruct(*reinterpret_cast<const vku::safe_VkAttachmentDescriptionStencilLayout*>(ref_pNext),
+                              *reinterpret_cast<const VkAttachmentDescriptionStencilLayout*>(res_pNext));
+                break;
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    EXPECT_EQ(ref.format, res.format);
+    EXPECT_EQ(ref.samples, res.samples);
+    EXPECT_EQ(ref.loadOp, res.loadOp);
+    EXPECT_EQ(ref.storeOp, res.storeOp);
+    EXPECT_EQ(ref.stencilLoadOp, res.stencilLoadOp);
+    EXPECT_EQ(ref.stencilStoreOp, res.stencilStoreOp);
+    EXPECT_EQ(ref.initialLayout, res.initialLayout);
+    EXPECT_EQ(ref.finalLayout, res.finalLayout);
+}
+
+void CompareStruct(const vku::safe_VkAttachmentReference2& ref, const VkAttachmentReference2& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.attachment, res.attachment);
+    EXPECT_EQ(ref.layout, res.layout);
+    EXPECT_EQ(ref.aspectMask, res.aspectMask);
+}
+
+void CompareStruct(const vku::safe_VkFragmentShadingRateAttachmentInfoKHR& ref, const VkFragmentShadingRateAttachmentInfoKHR& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    if (ref.pFragmentShadingRateAttachment) {
+        CompareStruct(*ref.pFragmentShadingRateAttachment, *res.pFragmentShadingRateAttachment);
+    } else {
+        EXPECT_EQ(nullptr, res.pFragmentShadingRateAttachment);
+    }
+    EXPECT_EQ(ref.shadingRateAttachmentTexelSize.width, res.shadingRateAttachmentTexelSize.width);
+    EXPECT_EQ(ref.shadingRateAttachmentTexelSize.height, res.shadingRateAttachmentTexelSize.height);
+}
+
+void CompareStruct(const vku::safe_VkSubpassDescriptionDepthStencilResolve& ref,
+                   const VkSubpassDescriptionDepthStencilResolve& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    if (ref.pDepthStencilResolveAttachment) {
+        CompareStruct(*ref.pDepthStencilResolveAttachment, *res.pDepthStencilResolveAttachment);
+    } else {
+        EXPECT_EQ(nullptr, res.pDepthStencilResolveAttachment);
+    }
+}
+
+void CompareStruct(const vku::safe_VkSubpassDescription2& ref, const VkSubpassDescription2& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            case VK_STRUCTURE_TYPE_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR:
+                CompareStruct(*reinterpret_cast<const vku::safe_VkFragmentShadingRateAttachmentInfoKHR*>(ref_pNext),
+                              *reinterpret_cast<const VkFragmentShadingRateAttachmentInfoKHR*>(res_pNext));
+                break;
+            case VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE:
+                CompareStruct(*reinterpret_cast<const vku::safe_VkSubpassDescriptionDepthStencilResolve*>(ref_pNext),
+                              *reinterpret_cast<const VkSubpassDescriptionDepthStencilResolve*>(res_pNext));
+                break;
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    EXPECT_EQ(ref.pipelineBindPoint, res.pipelineBindPoint);
+    EXPECT_EQ(ref.inputAttachmentCount, res.inputAttachmentCount);
+    if (ref.inputAttachmentCount) {
+        for (uint32_t j = 0; j < ref.inputAttachmentCount; ++j) {
+            EXPECT_EQ(ref.pInputAttachments[j].attachment, res.pInputAttachments[j].attachment);
+            EXPECT_EQ(ref.pInputAttachments[j].layout, res.pInputAttachments[j].layout);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pInputAttachments);
+    }
+    EXPECT_EQ(ref.colorAttachmentCount, res.colorAttachmentCount);
+    if (ref.colorAttachmentCount) {
+        for (uint32_t j = 0; j < ref.colorAttachmentCount; ++j) {
+            EXPECT_EQ(ref.pColorAttachments[j].attachment, res.pColorAttachments[j].attachment);
+            EXPECT_EQ(ref.pColorAttachments[j].layout, res.pColorAttachments[j].layout);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pColorAttachments);
+    }
+    if (ref.pResolveAttachments) {
+        for (uint32_t j = 0; j < ref.colorAttachmentCount; ++j) {
+            EXPECT_EQ(ref.pResolveAttachments[j].attachment, res.pResolveAttachments[j].attachment);
+            EXPECT_EQ(ref.pResolveAttachments[j].layout, res.pResolveAttachments[j].layout);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pResolveAttachments);
+    }
+    if (ref.pDepthStencilAttachment) {
+        for (uint32_t j = 0; j < ref.colorAttachmentCount; ++j) {
+            EXPECT_EQ(ref.pDepthStencilAttachment[j].attachment, res.pDepthStencilAttachment[j].attachment);
+            EXPECT_EQ(ref.pDepthStencilAttachment[j].layout, res.pDepthStencilAttachment[j].layout);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pDepthStencilAttachment);
+    }
+    if (ref.pPreserveAttachments) {
+        for (uint32_t j = 0; j < ref.colorAttachmentCount; ++j) {
+            EXPECT_EQ(ref.pPreserveAttachments[j], res.pPreserveAttachments[j]);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pPreserveAttachments);
+    }
+}
+
+void CompareStruct(const vku::safe_VkMemoryBarrier2& ref, const VkMemoryBarrier2KHR& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    EXPECT_EQ(ref.srcStageMask, res.srcStageMask);
+    EXPECT_EQ(ref.srcAccessMask, res.srcAccessMask);
+    EXPECT_EQ(ref.dstStageMask, res.dstStageMask);
+    EXPECT_EQ(ref.dstAccessMask, res.dstAccessMask);
+}
+
+void CompareStruct(const vku::safe_VkSubpassDependency2& ref, const VkSubpassDependency2& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            case VK_STRUCTURE_TYPE_MEMORY_BARRIER_2_KHR:
+                CompareStruct(*reinterpret_cast<const vku::safe_VkMemoryBarrier2*>(ref_pNext),
+                              *reinterpret_cast<const VkMemoryBarrier2KHR*>(res_pNext));
+                break;
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.srcSubpass, res.srcSubpass);
+    EXPECT_EQ(ref.dstSubpass, res.dstSubpass);
+    EXPECT_EQ(ref.srcStageMask, res.srcStageMask);
+    EXPECT_EQ(ref.dstStageMask, res.dstStageMask);
+    EXPECT_EQ(ref.srcAccessMask, res.srcAccessMask);
+    EXPECT_EQ(ref.dstAccessMask, res.dstAccessMask);
+    EXPECT_EQ(ref.dependencyFlags, res.dependencyFlags);
+}
+
+void CompareStruct(const vku::safe_VkRenderPassCreateInfo2& ref, const VkRenderPassCreateInfo2& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            case VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO:
+                CompareStruct(*reinterpret_cast<const vku::safe_VkRenderPassInputAttachmentAspectCreateInfo*>(ref_pNext),
+                              *reinterpret_cast<const VkRenderPassInputAttachmentAspectCreateInfo*>(res_pNext));
+                break;
+            case VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO:
+                CompareStruct(*reinterpret_cast<const vku::safe_VkRenderPassMultiviewCreateInfo*>(ref_pNext),
+                              *reinterpret_cast<const VkRenderPassMultiviewCreateInfo*>(res_pNext));
+                break;
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    EXPECT_EQ(ref.attachmentCount, res.attachmentCount);
+    if (ref.attachmentCount) {
+        for (uint32_t i = 0; i < ref.attachmentCount; ++i) {
+            CompareStruct(ref.pAttachments[i], res.pAttachments[i]);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pAttachments);
+    }
+    EXPECT_EQ(ref.subpassCount, res.subpassCount);
+    if (ref.subpassCount) {
+        for (uint32_t i = 0; i < ref.subpassCount; ++i) {
+            CompareStruct(ref.pSubpasses[i], res.pSubpasses[i]);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pSubpasses);
+    }
+    EXPECT_EQ(ref.dependencyCount, res.dependencyCount);
+    if (ref.dependencyCount) {
+        for (uint32_t i = 0; i < ref.dependencyCount; ++i) {
+            CompareStruct(ref.pDependencies[i], res.pDependencies[i]);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pDependencies);
+    }
+    if (ref.correlatedViewMaskCount) {
+        for (uint32_t i = 0; i < ref.correlatedViewMaskCount; ++i) {
+            EXPECT_EQ(ref.pCorrelatedViewMasks[i], res.pCorrelatedViewMasks[i]);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pCorrelatedViewMasks);
+    }
+}
+
+void CompareStruct(const vku::safe_VkPipelineShaderStageRequiredSubgroupSizeCreateInfo& ref,
+                   const VkPipelineShaderStageRequiredSubgroupSizeCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    EXPECT_EQ(ref.requiredSubgroupSize, res.requiredSubgroupSize);
+}
+
+void CompareStruct(const vku::safe_VkPipelineShaderStageCreateInfo& ref, const VkPipelineShaderStageCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            case VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO:
+                CompareStruct(*reinterpret_cast<const vku::safe_VkPipelineShaderStageRequiredSubgroupSizeCreateInfo*>(ref_pNext),
+                              *reinterpret_cast<const VkPipelineShaderStageRequiredSubgroupSizeCreateInfo*>(res_pNext));
+                break;
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    EXPECT_EQ(ref.stage, res.stage);
+    EXPECT_STREQ(ref.pName, res.pName);
+    if (ref.pSpecializationInfo) {
+        if (ref.pSpecializationInfo->mapEntryCount) {
+            for (uint32_t i = 0; i < ref.pSpecializationInfo->mapEntryCount; ++i) {
+                EXPECT_EQ(ref.pSpecializationInfo->pMapEntries[i].constantID, res.pSpecializationInfo->pMapEntries[i].constantID);
+                EXPECT_EQ(ref.pSpecializationInfo->pMapEntries[i].constantID, res.pSpecializationInfo->pMapEntries[i].constantID);
+                EXPECT_EQ(ref.pSpecializationInfo->pMapEntries[i].constantID, res.pSpecializationInfo->pMapEntries[i].constantID);
+            }
+        } else {
+            EXPECT_EQ(nullptr, res.pSpecializationInfo->pMapEntries);
+        }
+        for (uint32_t i = 0; i < ref.pSpecializationInfo->dataSize; ++i) {
+            EXPECT_EQ(reinterpret_cast<const uint8_t*>(ref.pSpecializationInfo->pData)[i],
+                      reinterpret_cast<const uint8_t*>(res.pSpecializationInfo->pData)[i]);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pSpecializationInfo);
+    }
+}
+
+void CompareStruct(const vku::safe_VkComputePipelineCreateInfo& ref, const VkComputePipelineCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    CompareStruct(ref.stage, res.stage);
+    EXPECT_EQ(ref.layout, res.layout);
+    EXPECT_EQ(ref.basePipelineHandle, res.basePipelineHandle);
+    EXPECT_EQ(ref.basePipelineIndex, res.basePipelineIndex);
+}
+
+void CompareStruct(const vku::safe_VkPipelineDiscardRectangleStateCreateInfoEXT& ref,
+                   const VkPipelineDiscardRectangleStateCreateInfoEXT& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    EXPECT_EQ(ref.flags, res.flags);
+    EXPECT_EQ(ref.discardRectangleMode, res.discardRectangleMode);
+    if (ref.discardRectangleCount) {
+        for (uint32_t i = 0; i < ref.discardRectangleCount; ++i) {
+            EXPECT_EQ(ref.pDiscardRectangles[i].offset.x, res.pDiscardRectangles[i].offset.x);
+            EXPECT_EQ(ref.pDiscardRectangles[i].offset.y, res.pDiscardRectangles[i].offset.y);
+            EXPECT_EQ(ref.pDiscardRectangles[i].extent.width, res.pDiscardRectangles[i].extent.width);
+            EXPECT_EQ(ref.pDiscardRectangles[i].extent.height, res.pDiscardRectangles[i].extent.height);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pDiscardRectangles);
+    }
+}
+
+void CompareStruct(const vku::safe_VkPipelineVertexInputStateCreateInfo& ref, const VkPipelineVertexInputStateCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    if (ref.vertexBindingDescriptionCount) {
+        for (uint32_t i = 0; i < ref.vertexBindingDescriptionCount; ++i) {
+            EXPECT_EQ(ref.pVertexBindingDescriptions[i].binding, res.pVertexBindingDescriptions[i].binding);
+            EXPECT_EQ(ref.pVertexBindingDescriptions[i].stride, res.pVertexBindingDescriptions[i].stride);
+            EXPECT_EQ(ref.pVertexBindingDescriptions[i].inputRate, res.pVertexBindingDescriptions[i].inputRate);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pVertexBindingDescriptions);
+    }
+    if (ref.vertexAttributeDescriptionCount) {
+        for (uint32_t i = 0; i < ref.vertexAttributeDescriptionCount; ++i) {
+            EXPECT_EQ(ref.pVertexAttributeDescriptions[i].location, res.pVertexAttributeDescriptions[i].location);
+            EXPECT_EQ(ref.pVertexAttributeDescriptions[i].binding, res.pVertexAttributeDescriptions[i].binding);
+            EXPECT_EQ(ref.pVertexAttributeDescriptions[i].format, res.pVertexAttributeDescriptions[i].format);
+            EXPECT_EQ(ref.pVertexAttributeDescriptions[i].offset, res.pVertexAttributeDescriptions[i].offset);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pVertexAttributeDescriptions);
+    }
+}
+
+void CompareStruct(const vku::safe_VkPipelineInputAssemblyStateCreateInfo& ref, const VkPipelineInputAssemblyStateCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    EXPECT_EQ(ref.topology, res.topology);
+    EXPECT_EQ(ref.primitiveRestartEnable, res.primitiveRestartEnable);
+}
+
+void CompareStruct(const vku::safe_VkPipelineTessellationStateCreateInfo& ref, const VkPipelineTessellationStateCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    EXPECT_EQ(ref.patchControlPoints, res.patchControlPoints);
+}
+
+void CompareStruct(const vku::safe_VkPipelineViewportStateCreateInfo& ref, const VkPipelineViewportStateCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    if (ref.viewportCount) {
+        for (uint32_t i = 0; i < ref.viewportCount; ++i) {
+            EXPECT_EQ(ref.pViewports[i].x, res.pViewports[i].x);
+            EXPECT_EQ(ref.pViewports[i].y, res.pViewports[i].y);
+            EXPECT_EQ(ref.pViewports[i].width, res.pViewports[i].width);
+            EXPECT_EQ(ref.pViewports[i].height, res.pViewports[i].height);
+            EXPECT_EQ(ref.pViewports[i].minDepth, res.pViewports[i].minDepth);
+            EXPECT_EQ(ref.pViewports[i].maxDepth, res.pViewports[i].maxDepth);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pViewports);
+    }
+    if (ref.scissorCount) {
+        for (uint32_t i = 0; i < ref.scissorCount; ++i) {
+            EXPECT_EQ(ref.pScissors[i].offset.x, res.pScissors[i].offset.x);
+            EXPECT_EQ(ref.pScissors[i].offset.y, res.pScissors[i].offset.y);
+            EXPECT_EQ(ref.pScissors[i].extent.width, res.pScissors[i].extent.width);
+            EXPECT_EQ(ref.pScissors[i].extent.height, res.pScissors[i].extent.height);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pViewports);
+    }
+}
+
+void CompareStruct(const vku::safe_VkPipelineRasterizationStateCreateInfo& ref, const VkPipelineRasterizationStateCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    EXPECT_EQ(ref.depthClampEnable, res.depthClampEnable);
+    EXPECT_EQ(ref.rasterizerDiscardEnable, res.rasterizerDiscardEnable);
+    EXPECT_EQ(ref.polygonMode, res.polygonMode);
+    EXPECT_EQ(ref.cullMode, res.cullMode);
+    EXPECT_EQ(ref.frontFace, res.frontFace);
+    EXPECT_EQ(ref.depthBiasEnable, res.depthBiasEnable);
+    EXPECT_EQ(ref.depthBiasConstantFactor, res.depthBiasConstantFactor);
+    EXPECT_EQ(ref.depthBiasClamp, res.depthBiasClamp);
+    EXPECT_EQ(ref.depthBiasSlopeFactor, res.depthBiasSlopeFactor);
+    EXPECT_EQ(ref.lineWidth, res.lineWidth);
+}
+
+void CompareStruct(const vku::safe_VkPipelineMultisampleStateCreateInfo& ref, const VkPipelineMultisampleStateCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    EXPECT_EQ(ref.rasterizationSamples, res.rasterizationSamples);
+    EXPECT_EQ(ref.sampleShadingEnable, res.sampleShadingEnable);
+    EXPECT_EQ(ref.minSampleShading, res.minSampleShading);
+    if (ref.pSampleMask) {
+        EXPECT_EQ(*ref.pSampleMask, *res.pSampleMask);
+    } else {
+        EXPECT_EQ(nullptr, res.pSampleMask);
+    }
+    EXPECT_EQ(ref.alphaToCoverageEnable, res.alphaToCoverageEnable);
+    EXPECT_EQ(ref.alphaToOneEnable, res.alphaToOneEnable);
+}
+
+void CompareStruct(const vku::safe_VkPipelineDepthStencilStateCreateInfo& ref, const VkPipelineDepthStencilStateCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    EXPECT_EQ(ref.depthTestEnable, res.depthTestEnable);
+    EXPECT_EQ(ref.depthWriteEnable, res.depthWriteEnable);
+    EXPECT_EQ(ref.depthCompareOp, res.depthCompareOp);
+    EXPECT_EQ(ref.depthBoundsTestEnable, res.depthBoundsTestEnable);
+    EXPECT_EQ(ref.stencilTestEnable, res.stencilTestEnable);
+    EXPECT_EQ(ref.front.failOp, res.front.failOp);
+    EXPECT_EQ(ref.front.passOp, res.front.passOp);
+    EXPECT_EQ(ref.front.depthFailOp, res.front.depthFailOp);
+    EXPECT_EQ(ref.front.compareOp, res.front.compareOp);
+    EXPECT_EQ(ref.front.compareMask, res.front.compareMask);
+    EXPECT_EQ(ref.front.writeMask, res.front.writeMask);
+    EXPECT_EQ(ref.front.reference, res.front.reference);
+    EXPECT_EQ(ref.back.failOp, res.back.failOp);
+    EXPECT_EQ(ref.back.passOp, res.back.passOp);
+    EXPECT_EQ(ref.back.depthFailOp, res.back.depthFailOp);
+    EXPECT_EQ(ref.back.compareOp, res.back.compareOp);
+    EXPECT_EQ(ref.back.compareMask, res.back.compareMask);
+    EXPECT_EQ(ref.back.writeMask, res.back.writeMask);
+    EXPECT_EQ(ref.back.reference, res.back.reference);
+    EXPECT_EQ(ref.minDepthBounds, res.minDepthBounds);
+    EXPECT_EQ(ref.maxDepthBounds, res.maxDepthBounds);
+}
+
+void CompareStruct(const vku::safe_VkPipelineColorBlendStateCreateInfo& ref, const VkPipelineColorBlendStateCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    EXPECT_EQ(ref.logicOpEnable, res.logicOpEnable);
+    EXPECT_EQ(ref.logicOp, res.logicOp);
+    if (ref.attachmentCount) {
+        for (uint32_t i = 0; i < ref.attachmentCount; ++i) {
+            EXPECT_EQ(ref.pAttachments[i].blendEnable, res.pAttachments[i].blendEnable);
+            EXPECT_EQ(ref.pAttachments[i].srcColorBlendFactor, res.pAttachments[i].srcColorBlendFactor);
+            EXPECT_EQ(ref.pAttachments[i].dstColorBlendFactor, res.pAttachments[i].dstColorBlendFactor);
+            EXPECT_EQ(ref.pAttachments[i].colorBlendOp, res.pAttachments[i].colorBlendOp);
+            EXPECT_EQ(ref.pAttachments[i].srcAlphaBlendFactor, res.pAttachments[i].srcAlphaBlendFactor);
+            EXPECT_EQ(ref.pAttachments[i].dstAlphaBlendFactor, res.pAttachments[i].dstAlphaBlendFactor);
+            EXPECT_EQ(ref.pAttachments[i].alphaBlendOp, res.pAttachments[i].alphaBlendOp);
+            EXPECT_EQ(ref.pAttachments[i].colorWriteMask, res.pAttachments[i].colorWriteMask);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pAttachments);
+    }
+    for (uint32_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(ref.blendConstants[i], res.blendConstants[i]);
+    }
+}
+
+void CompareStruct(const vku::safe_VkPipelineDynamicStateCreateInfo& ref, const VkPipelineDynamicStateCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    if (ref.dynamicStateCount) {
+        for (uint32_t i = 0; i < ref.dynamicStateCount; ++i) {
+            EXPECT_EQ(ref.pDynamicStates[i], res.pDynamicStates[i]);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.pDynamicStates);
+    }
+}
+
+void CompareStruct(const vku::safe_VkGraphicsPipelineCreateInfo& ref, const VkGraphicsPipelineCreateInfo& res) {
+    EXPECT_EQ(ref.sType, res.sType);
+    for (const VkBaseInStructure *ref_pNext = reinterpret_cast<const VkBaseInStructure*>(ref.pNext),
+                                 *res_pNext = reinterpret_cast<const VkBaseInStructure*>(res.pNext);
+         ref_pNext != nullptr; ref_pNext = ref_pNext->pNext, res_pNext = res_pNext->pNext) {
+        switch (ref_pNext->sType) {
+            case VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT:
+                CompareStruct(*reinterpret_cast<const vku::safe_VkPipelineDiscardRectangleStateCreateInfoEXT*>(ref_pNext),
+                              *reinterpret_cast<const VkPipelineDiscardRectangleStateCreateInfoEXT*>(res_pNext));
+                break;
+            default:
+                FAIL() << "Unkown sType found in reference struct";
+                break;
+        }
+    }
+    EXPECT_EQ(ref.flags, res.flags);
+    for (uint32_t i = 0; i < ref.stageCount; ++i) {
+        CompareStruct(ref.pStages[i], res.pStages[i]);
+    }
+    if (ref.pVertexInputState) {
+        CompareStruct(*ref.pVertexInputState, *res.pVertexInputState);
+    } else {
+        EXPECT_EQ(nullptr, res.pVertexInputState);
+    }
+    if (ref.pInputAssemblyState) {
+        CompareStruct(*ref.pInputAssemblyState, *res.pInputAssemblyState);
+    } else {
+        EXPECT_EQ(nullptr, res.pInputAssemblyState);
+    }
+    if (ref.pTessellationState) {
+        CompareStruct(*ref.pTessellationState, *res.pTessellationState);
+    } else {
+        EXPECT_EQ(nullptr, res.pTessellationState);
+    }
+    if (ref.pViewportState) {
+        CompareStruct(*ref.pViewportState, *res.pViewportState);
+    } else {
+        EXPECT_EQ(nullptr, res.pViewportState);
+    }
+    if (ref.pRasterizationState) {
+        CompareStruct(*ref.pRasterizationState, *res.pRasterizationState);
+    } else {
+        EXPECT_EQ(nullptr, res.pRasterizationState);
+    }
+    if (ref.pMultisampleState) {
+        CompareStruct(*ref.pMultisampleState, *res.pMultisampleState);
+    } else {
+        EXPECT_EQ(nullptr, res.pMultisampleState);
+    }
+    if (ref.pDepthStencilState) {
+        CompareStruct(*ref.pDepthStencilState, *res.pDepthStencilState);
+    } else {
+        EXPECT_EQ(nullptr, res.pDepthStencilState);
+    }
+    if (ref.pColorBlendState) {
+        CompareStruct(*ref.pColorBlendState, *res.pColorBlendState);
+    } else {
+        EXPECT_EQ(nullptr, res.pColorBlendState);
+    }
+    if (ref.pDynamicState) {
+        CompareStruct(*ref.pDynamicState, *res.pDynamicState);
+    } else {
+        EXPECT_EQ(nullptr, res.pDynamicState);
+    }
+    EXPECT_EQ(ref.basePipelineHandle, res.basePipelineHandle);
+    EXPECT_EQ(ref.basePipelineIndex, res.basePipelineIndex);
+}
+
+void EXPECT_UUIDEQ(uint8_t* it1, uint8_t* it2) {
+    for (unsigned int i = 0; i < VK_UUID_SIZE; ++i) {
+        EXPECT_EQ(it1[i], it2[i]);
+    }
+}
+
+template <typename UnionType>
+void CompareData(VpjData ref, VpjData res) {
+    if (ref.enabledExtensionCount) {
+        for (uint32_t i = 0; i < ref.enabledExtensionCount; ++i) {
+            EXPECT_STREQ(ref.ppEnabledExtensions[i], res.ppEnabledExtensions[i]);
+        }
+    } else {
+        EXPECT_EQ(nullptr, res.ppEnabledExtensions);
+    }
+    if constexpr (std::is_same_v<UnionType, VpjComputePipelineState>) {
+        CompareStruct(reinterpret_cast<const VkComputePipelineCreateInfo*>(ref.computePipelineState.pComputePipeline),
+                      *reinterpret_cast<const VkComputePipelineCreateInfo*>(res.computePipelineState.pComputePipeline));
+        if (ref.computePipelineState.immutableSamplerCount) {
+            for (uint32_t i = 0; i < ref.computePipelineState.immutableSamplerCount; ++i) {
+                CompareStruct(&reinterpret_cast<const VkSamplerCreateInfo*>(ref.computePipelineState.pImmutableSamplers)[i],
+                              reinterpret_cast<const VkSamplerCreateInfo*>(res.computePipelineState.pImmutableSamplers)[i],
+                              ref.computePipelineState.ppYcbcrSamplerNames);
+                EXPECT_STREQ(ref.computePipelineState.ppImmutableSamplerNames[i],
+                             res.computePipelineState.ppImmutableSamplerNames[i]);
+            }
+        } else {
+            EXPECT_EQ(nullptr, res.computePipelineState.pImmutableSamplers);
+        }
+        if (ref.computePipelineState.ycbcrSamplerCount) {
+            for (uint32_t i = 0; i < ref.computePipelineState.ycbcrSamplerCount; ++i) {
+                CompareStruct(
+                    &reinterpret_cast<const VkSamplerYcbcrConversionCreateInfo*>(ref.computePipelineState.pYcbcrSamplers)[i],
+                    reinterpret_cast<const VkSamplerYcbcrConversionCreateInfo*>(res.computePipelineState.pYcbcrSamplers)[i]);
+                EXPECT_STREQ(ref.computePipelineState.ppYcbcrSamplerNames[i], res.computePipelineState.ppYcbcrSamplerNames[i]);
+            }
+        } else {
+            EXPECT_EQ(nullptr, res.computePipelineState.pYcbcrSamplers);
+        }
+        if (ref.computePipelineState.descriptorSetLayoutCount) {
+            for (uint32_t i = 0; i < ref.computePipelineState.descriptorSetLayoutCount; ++i) {
+                CompareStruct(
+                    &reinterpret_cast<const VkDescriptorSetLayoutCreateInfo*>(ref.computePipelineState.pDescriptorSetLayouts)[i],
+                    reinterpret_cast<const VkDescriptorSetLayoutCreateInfo*>(res.computePipelineState.pDescriptorSetLayouts)[i],
+                    ref.computePipelineState.ppImmutableSamplerNames);
+                EXPECT_STREQ(ref.computePipelineState.ppDescriptorSetLayoutNames[i],
+                             res.computePipelineState.ppDescriptorSetLayoutNames[i]);
+            }
+        } else {
+            EXPECT_EQ(nullptr, res.computePipelineState.pDescriptorSetLayouts);
+        }
+        for (uint32_t i = 0; i < ref.computePipelineState.descriptorSetLayoutCount; ++i) {
+            EXPECT_EQ(ref.computePipelineState.pShaderFileNames[i].stage, res.computePipelineState.pShaderFileNames[i].stage);
+            EXPECT_STREQ(ref.computePipelineState.pShaderFileNames[i].pFilename,
+                         res.computePipelineState.pShaderFileNames[i].pFilename);
+        }
+        CompareStruct(reinterpret_cast<const VkPipelineLayoutCreateInfo*>(ref.computePipelineState.pPipelineLayout),
+                      *reinterpret_cast<const VkPipelineLayoutCreateInfo*>(res.computePipelineState.pPipelineLayout),
+                      ref.computePipelineState.ppDescriptorSetLayoutNames);
+        if (ref.computePipelineState.pPhysicalDeviceFeatures) {
+            CompareStruct(reinterpret_cast<const VkPhysicalDeviceFeatures2*>(ref.computePipelineState.pPhysicalDeviceFeatures),
+                          *reinterpret_cast<const VkPhysicalDeviceFeatures2*>(res.computePipelineState.pPhysicalDeviceFeatures));
+        } else {
+            EXPECT_EQ(nullptr, res.computePipelineState.pPhysicalDeviceFeatures);
+        }
+    } else if constexpr (std::is_same_v<UnionType, VpjGraphicsPipelineState>) {
+        CompareStruct(
+            vku::safe_VkGraphicsPipelineCreateInfo{
+                reinterpret_cast<const VkGraphicsPipelineCreateInfo*>(ref.graphicsPipelineState.pGraphicsPipeline), true, true},
+            *reinterpret_cast<const VkGraphicsPipelineCreateInfo*>(res.graphicsPipelineState.pGraphicsPipeline));
+        if (ref.graphicsPipelineState.immutableSamplerCount) {
+            for (uint32_t i = 0; i < ref.graphicsPipelineState.immutableSamplerCount; ++i) {
+                CompareStruct(&reinterpret_cast<const VkSamplerCreateInfo*>(ref.graphicsPipelineState.pImmutableSamplers)[i],
+                              reinterpret_cast<const VkSamplerCreateInfo*>(res.graphicsPipelineState.pImmutableSamplers)[i],
+                              ref.graphicsPipelineState.ppYcbcrSamplerNames);
+                EXPECT_STREQ(ref.graphicsPipelineState.ppImmutableSamplerNames[i],
+                             res.graphicsPipelineState.ppImmutableSamplerNames[i]);
+            }
+        } else {
+            EXPECT_EQ(nullptr, res.graphicsPipelineState.pImmutableSamplers);
+        }
+        if (ref.graphicsPipelineState.ycbcrSamplerCount) {
+            for (uint32_t i = 0; i < ref.graphicsPipelineState.ycbcrSamplerCount; ++i) {
+                CompareStruct(
+                    &reinterpret_cast<const VkSamplerYcbcrConversionCreateInfo*>(ref.graphicsPipelineState.pYcbcrSamplers)[i],
+                    reinterpret_cast<const VkSamplerYcbcrConversionCreateInfo*>(res.graphicsPipelineState.pYcbcrSamplers)[i]);
+                EXPECT_STREQ(ref.graphicsPipelineState.ppYcbcrSamplerNames[i], res.graphicsPipelineState.ppYcbcrSamplerNames[i]);
+            }
+        } else {
+            EXPECT_EQ(nullptr, res.graphicsPipelineState.pYcbcrSamplers);
+        }
+        if (ref.graphicsPipelineState.descriptorSetLayoutCount) {
+            for (uint32_t i = 0; i < ref.graphicsPipelineState.descriptorSetLayoutCount; ++i) {
+                CompareStruct(
+                    &reinterpret_cast<const VkDescriptorSetLayoutCreateInfo*>(ref.graphicsPipelineState.pDescriptorSetLayouts)[i],
+                    reinterpret_cast<const VkDescriptorSetLayoutCreateInfo*>(res.graphicsPipelineState.pDescriptorSetLayouts)[i],
+                    ref.graphicsPipelineState.ppImmutableSamplerNames);
+                EXPECT_STREQ(ref.graphicsPipelineState.ppDescriptorSetLayoutNames[i],
+                             res.graphicsPipelineState.ppDescriptorSetLayoutNames[i]);
+            }
+        } else {
+            EXPECT_EQ(nullptr, res.graphicsPipelineState.pDescriptorSetLayouts);
+        }
+        CompareStruct(reinterpret_cast<const VkPipelineLayoutCreateInfo*>(ref.graphicsPipelineState.pPipelineLayout),
+                      *reinterpret_cast<const VkPipelineLayoutCreateInfo*>(res.graphicsPipelineState.pPipelineLayout),
+                      ref.graphicsPipelineState.ppDescriptorSetLayoutNames);
+        for (uint32_t i = 0; i < ref.graphicsPipelineState.descriptorSetLayoutCount; ++i) {
+            EXPECT_EQ(ref.graphicsPipelineState.pShaderFileNames[i].stage, res.graphicsPipelineState.pShaderFileNames[i].stage);
+            EXPECT_STREQ(ref.graphicsPipelineState.pShaderFileNames[i].pFilename,
+                         res.graphicsPipelineState.pShaderFileNames[i].pFilename);
+        }
+        if (ref.graphicsPipelineState.pPhysicalDeviceFeatures) {
+            CompareStruct(reinterpret_cast<const VkPhysicalDeviceFeatures2*>(ref.graphicsPipelineState.pPhysicalDeviceFeatures),
+                          *reinterpret_cast<const VkPhysicalDeviceFeatures2*>(res.graphicsPipelineState.pPhysicalDeviceFeatures));
+        } else {
+            EXPECT_EQ(nullptr, res.graphicsPipelineState.pPhysicalDeviceFeatures);
+        }
+        if (reinterpret_cast<const VkBaseInStructure*>(ref.graphicsPipelineState.pRenderPass)->sType ==
+            VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO) {
+            CompareStruct(reinterpret_cast<const VkRenderPassCreateInfo*>(ref.graphicsPipelineState.pRenderPass),
+                          *reinterpret_cast<const VkRenderPassCreateInfo*>(res.graphicsPipelineState.pRenderPass));
+        } else {
+            CompareStruct(reinterpret_cast<const VkRenderPassCreateInfo2*>(ref.graphicsPipelineState.pRenderPass),
+                          *reinterpret_cast<const VkRenderPassCreateInfo2*>(res.graphicsPipelineState.pRenderPass));
+        }
+    } else {
+        FAIL() << "Invalid VpjData union type provided.";
+    }
+    EXPECT_UUIDEQ(ref.pipelineUUID, res.pipelineUUID);
+}

--- a/tests/pcjson/CMakeLists.txt
+++ b/tests/pcjson/CMakeLists.txt
@@ -24,6 +24,7 @@ macro(pcu_add_test)
     target_link_libraries(${_TEST_NAME} PRIVATE
         Vulkan::Headers
         Vulkan::UtilityHeaders
+        Vulkan::SafeStruct
         VulkanSC::PCJson
         GTest::gtest
         GTest::gtest_main

--- a/tests/pcjson/pcjson_test_gen.cpp
+++ b/tests/pcjson/pcjson_test_gen.cpp
@@ -185,141 +185,17 @@ TEST_F(Gen, VkShaderModuleCreateInfo) {
     }
 }
 
-// TODO: Use getVkDeviceObjectReservationCreateInfo once safe struct issue is resolved.
-// see: https://github.com/KhronosGroup/Vulkan-Utility-Libraries/issues/343
 TEST_F(Gen, VkDeviceObjectReservationCreateInfo) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex object reservation create info JSON");
 
-    std::string ref_json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_DEVICE_OBJECT_RESERVATION_CREATE_INFO",
-        "pNext": "NULL",
-        "pipelineCacheCreateInfoCount": 1,
-        "pPipelineCacheCreateInfos": [
-            {
-                "sType": "VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO",
-                "pNext": "NULL",
-                "flags": "VK_PIPELINE_CACHE_CREATE_READ_ONLY_BIT | VK_PIPELINE_CACHE_CREATE_USE_APPLICATION_STORAGE_BIT",
-                "initialDataSize": 3,
-                "pInitialData": "abcd"
-            }
-        ],
-        "pipelinePoolSizeCount": 1,
-        "pPipelinePoolSizes": [
-            {
-                "sType": "VK_STRUCTURE_TYPE_PIPELINE_POOL_SIZE",
-                "pNext": "NULL",
-                "poolEntryCount": 1,
-                "poolEntrySize": 1048576
-            }
-        ],
-        "semaphoreRequestCount": 0,
-        "commandBufferRequestCount": 1,
-        "fenceRequestCount": 1,
-        "deviceMemoryRequestCount": 2,
-        "bufferRequestCount": 2,
-        "imageRequestCount": 0,
-        "eventRequestCount": 0,
-        "queryPoolRequestCount": 0,
-        "bufferViewRequestCount": 0,
-        "imageViewRequestCount": 0,
-        "layeredImageViewRequestCount": 0,
-        "pipelineCacheRequestCount": 1,
-        "pipelineLayoutRequestCount": 1,
-        "renderPassRequestCount": 1,
-        "graphicsPipelineRequestCount": 0,
-        "computePipelineRequestCount": 1,
-        "descriptorSetLayoutRequestCount": 1,
-        "samplerRequestCount": 0,
-        "descriptorPoolRequestCount": 1,
-        "descriptorSetRequestCount": 1,
-        "framebufferRequestCount": 0,
-        "commandPoolRequestCount": 2,
-        "samplerYcbcrConversionRequestCount": 0,
-        "surfaceRequestCount": 0,
-        "swapchainRequestCount": 1,
-        "displayModeRequestCount": 0,
-        "subpassDescriptionRequestCount": 1,
-        "attachmentDescriptionRequestCount": 2,
-        "descriptorSetLayoutBindingRequestCount": 2,
-        "descriptorSetLayoutBindingLimit": 2,
-        "maxImageViewMipLevels": 1,
-        "maxImageViewArrayLayers": 1,
-        "maxLayeredImageViewMipLevels": 0,
-        "maxOcclusionQueriesPerPool": 0,
-        "maxPipelineStatisticsQueriesPerPool": 0,
-        "maxTimestampQueriesPerPool": 0,
-        "maxImmutableSamplersPerDescriptorSetLayout": 0
-    })"};
+    for (auto seed : {0}) {
+        auto [ci_in, ref_json] = getVkDeviceObjectReservationCreateInfo(seed);
 
-    VkDeviceObjectReservationCreateInfo dor_ci{};
-
-    dor_ci.sType = VK_STRUCTURE_TYPE_DEVICE_OBJECT_RESERVATION_CREATE_INFO;
-    dor_ci.pNext = nullptr;
-
-    VkPipelineCacheCreateInfo pipelineCacheCreateInfos[1] = {};
-    dor_ci.pipelineCacheCreateInfoCount = 1;
-    pipelineCacheCreateInfos[0].sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
-    pipelineCacheCreateInfos[0].pNext = nullptr;
-    pipelineCacheCreateInfos[0].flags =
-        VK_PIPELINE_CACHE_CREATE_READ_ONLY_BIT | VK_PIPELINE_CACHE_CREATE_USE_APPLICATION_STORAGE_BIT;
-
-    uint8_t initialData[3] = {0b01101001, 0b10110111, 0b00011101};
-    pipelineCacheCreateInfos[0].initialDataSize = 3;
-    pipelineCacheCreateInfos->pInitialData = initialData;
-
-    dor_ci.pPipelineCacheCreateInfos = pipelineCacheCreateInfos;
-
-    VkPipelinePoolSize pipelinePoolSizes[1] = {};
-    dor_ci.pipelinePoolSizeCount = 1;
-    pipelinePoolSizes[0].sType = VK_STRUCTURE_TYPE_PIPELINE_POOL_SIZE;
-    pipelinePoolSizes[0].pNext = nullptr;
-    pipelinePoolSizes[0].poolEntryCount = 1;
-    pipelinePoolSizes[0].poolEntrySize = 1048576;
-    dor_ci.pPipelinePoolSizes = pipelinePoolSizes;
-
-    dor_ci.semaphoreRequestCount = 0;
-    dor_ci.commandBufferRequestCount = 1;
-    dor_ci.fenceRequestCount = 1;
-    dor_ci.deviceMemoryRequestCount = 2;
-    dor_ci.bufferRequestCount = 2;
-    dor_ci.imageRequestCount = 0;
-    dor_ci.eventRequestCount = 0;
-    dor_ci.queryPoolRequestCount = 0;
-    dor_ci.bufferViewRequestCount = 0;
-    dor_ci.imageViewRequestCount = 0;
-    dor_ci.layeredImageViewRequestCount = 0;
-    dor_ci.pipelineCacheRequestCount = 1;
-    dor_ci.pipelineLayoutRequestCount = 1;
-    dor_ci.renderPassRequestCount = 1;
-    dor_ci.graphicsPipelineRequestCount = 0;
-    dor_ci.computePipelineRequestCount = 1;
-    dor_ci.descriptorSetLayoutRequestCount = 1;
-    dor_ci.samplerRequestCount = 0;
-    dor_ci.descriptorPoolRequestCount = 1;
-    dor_ci.descriptorSetRequestCount = 1;
-    dor_ci.framebufferRequestCount = 0;
-    dor_ci.commandPoolRequestCount = 2;
-    dor_ci.samplerYcbcrConversionRequestCount = 0;
-    dor_ci.surfaceRequestCount = 0;
-    dor_ci.swapchainRequestCount = 1;
-    dor_ci.displayModeRequestCount = 0;
-    dor_ci.subpassDescriptionRequestCount = 1;
-    dor_ci.attachmentDescriptionRequestCount = 2;
-    dor_ci.descriptorSetLayoutBindingRequestCount = 2;
-    dor_ci.descriptorSetLayoutBindingLimit = 2;
-    dor_ci.maxImageViewMipLevels = 1;
-    dor_ci.maxImageViewArrayLayers = 1;
-    dor_ci.maxLayeredImageViewMipLevels = 0;
-    dor_ci.maxOcclusionQueriesPerPool = 0;
-    dor_ci.maxPipelineStatisticsQueriesPerPool = 0;
-    dor_ci.maxTimestampQueriesPerPool = 0;
-    dor_ci.maxImmutableSamplersPerDescriptorSetLayout = 0;
-
-    const char* result_json = nullptr;
-
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &dor_ci, &result_json, &msg_));
-    CHECK_GEN();
-    EXPECT_TRUE(CompareJson(result_json, ref_json));
+        const char* result_json = nullptr;
+        EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci_in, &result_json, &msg_));
+        CHECK_GEN();
+        EXPECT_TRUE(CompareJson(result_json, ref_json));
+    }
 }
 
 TEST_F(Gen, VkPipelineOfflineCreateInfo) {

--- a/tests/pcjson/pcjson_test_gen.cpp
+++ b/tests/pcjson/pcjson_test_gen.cpp
@@ -56,166 +56,137 @@ class Gen : public testing::Test {
 TEST_F(Gen, VkPhysicalDeviceFeatures2) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex physical device features 2 JSON");
 
-    auto [pdf, ref_json] = getVkPhysicalDeviceFeatures2(
-        0, std::make_tuple(getVkPhysicalDeviceVulkan11Features(), getVkPhysicalDeviceScalarBlockLayoutFeatures()));
+    for (auto seed : {0, 1, 2}) {
+        auto [pdf_in, ref_json] = getVkPhysicalDeviceFeatures2(seed);
 
-    const char* result_json = nullptr;
-
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &pdf, &result_json, &msg_));
-    CHECK_GEN();
-    EXPECT_TRUE(CompareJson(result_json, ref_json));
+        const char* result_json = nullptr;
+        EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &pdf_in, &result_json, &msg_));
+        CHECK_GEN();
+        EXPECT_TRUE(CompareJson(result_json, ref_json));
+    }
 }
 
 TEST_F(Gen, VkGraphicsPipelineCreateInfo) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex graphics pipeline create info JSON");
 
-    auto [ci, ref_json] = getVkGraphicsPipelineCreateInfo(
-        0,
-        {getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_VERTEX_BIT),
-         getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT),
-         getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT,
-                                            std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo())),
-         getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_GEOMETRY_BIT),
-         getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_FRAGMENT_BIT)},
-        std::make_tuple(getVkPipelineDiscardRectangleStateCreateInfoEXT()));
+    for (auto seed : {0}) {
+        auto [ci_in, ref_json] = getVkGraphicsPipelineCreateInfo(seed);
 
-    const char* result_json = nullptr;
-
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci, &result_json, &msg_));
-    CHECK_GEN();
-    EXPECT_TRUE(CompareJson(result_json, ref_json));
+        const char* result_json = nullptr;
+        EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci_in, &result_json, &msg_));
+        CHECK_GEN();
+        EXPECT_TRUE(CompareJson(result_json, ref_json));
+    }
 }
 
 TEST_F(Gen, VkComputePipelineCreateInfo) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex compute pipeline create info JSON");
 
-    auto [ci, ref_json] = getVkComputePipelineCreateInfo(getVkPipelineShaderStageCreateInfo(
-        0, VK_SHADER_STAGE_COMPUTE_BIT, std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo())));
+    for (auto seed : {0, 1}) {
+        auto [ci_in, ref_json] = getVkComputePipelineCreateInfo(seed);
 
-    const char* result_json = nullptr;
-
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci, &result_json, &msg_));
-    CHECK_GEN();
-    EXPECT_TRUE(CompareJson(result_json, ref_json));
+        const char* result_json = nullptr;
+        EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci_in, &result_json, &msg_));
+        CHECK_GEN();
+        EXPECT_TRUE(CompareJson(result_json, ref_json));
+    }
 }
 
 TEST_F(Gen, VkSamplerYcbcrConversionCreateInfo) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex ycbcr conversion create info JSON");
 
-    auto [ci, ref_json] = getVkSamplerYcbcrConversionCreateInfo();
+    for (auto seed : {0, 1, 2}) {
+        auto [ci_in, ref_json] = getVkSamplerYcbcrConversionCreateInfo(seed);
 
-    const char* result_json = nullptr;
-
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci, &result_json, &msg_));
-    CHECK_GEN();
-    EXPECT_TRUE(CompareJson(result_json, ref_json));
+        const char* result_json = nullptr;
+        EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci_in, &result_json, &msg_));
+        CHECK_GEN();
+        EXPECT_TRUE(CompareJson(result_json, ref_json));
+    }
 }
 
 TEST_F(Gen, VkSamplerCreateInfo) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex sampler create info JSON");
 
-    {
-        auto [ci, ref_json] = getVkSamplerCreateInfo();
+    for (auto seed : {0, 1, 2}) {
+        for (auto param : std::vector<SamplerParams>{{}, {VkSamplerYcbcrConversion(12345)}}) {
+            auto [ci_in, ref_json] = getVkSamplerCreateInfo(seed, param);
 
-        const char* result_json = nullptr;
-
-        EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, ci.ptr(), &result_json, &msg_));
-        CHECK_GEN(true);
-        EXPECT_TRUE(CompareJson(result_json, ref_json));
-    }
-    {
-        auto [ci, ref_json] =
-            getVkSamplerCreateInfo(1, std::make_tuple(getVkSamplerYcbcrConversionInfo(VkSamplerYcbcrConversion(12345)),
-                                                      getVkSamplerReductionModeCreateInfo(1)));
-
-        const char* result_json = nullptr;
-
-        EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, ci.ptr(), &result_json, &msg_));
-        CHECK_GEN(true);
-        EXPECT_TRUE(CompareJson(result_json, ref_json));
+            const char* result_json = nullptr;
+            EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci_in, &result_json, &msg_));
+            CHECK_GEN(true);
+            EXPECT_TRUE(CompareJson(result_json, ref_json));
+        }
     }
 }
 
 TEST_F(Gen, VkDescriptorSetLayoutCreateInfo) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex descriptor set layout create info JSON");
 
-    auto [ci, ref_json] = getVkDescriptorSetLayoutCreateInfo(0,
-                                                             {{1, VK_SHADER_STAGE_VERTEX_BIT},
-                                                              {1, VK_SHADER_STAGE_FRAGMENT_BIT, VkSampler(1)},
-                                                              {1, VK_SHADER_STAGE_FRAGMENT_BIT, VkSampler(2)}},
-                                                             std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
+    for (auto seed : {0, 1, 2, 3}) {
+        auto [ci_in, ref_json] = getVkDescriptorSetLayoutCreateInfo(seed);
 
-    const char* result_json = nullptr;
-
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci, &result_json, &msg_));
-    CHECK_GEN();
-    EXPECT_TRUE(CompareJson(result_json, ref_json));
+        const char* result_json = nullptr;
+        EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci_in, &result_json, &msg_));
+        CHECK_GEN();
+        EXPECT_TRUE(CompareJson(result_json, ref_json));
+    }
 }
 
 TEST_F(Gen, VkPipelineLayoutCreateInfo) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex pipeline layout create info JSON");
 
-    auto [ci, ref_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(12345)}});
+    for (auto seed : {0, 1, 2, 3}) {
+        auto [ci_in, ref_json] = getVkPipelineLayoutCreateInfo(seed);
 
-    const char* result_json = nullptr;
-
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci, &result_json, &msg_));
-    CHECK_GEN();
-    EXPECT_TRUE(CompareJson(result_json, ref_json));
+        const char* result_json = nullptr;
+        EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci_in, &result_json, &msg_));
+        CHECK_GEN();
+        EXPECT_TRUE(CompareJson(result_json, ref_json));
+    }
 }
 
 TEST_F(Gen, VkRenderPassCreateInfo) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex render pass create info JSON");
 
-    auto [ci, ref_json] = getVkRenderPassCreateInfo(
-        0, std::make_tuple(getVkRenderPassInputAttachmentAspectCreateInfo(), getVkRenderPassMultiviewCreateInfo()));
+    for (auto seed : {0, 1, 2, 3}) {
+        auto [ci_in, ref_json] = getVkRenderPassCreateInfo(seed);
 
-    const char* result_json = nullptr;
-
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci, &result_json, &msg_));
-    CHECK_GEN();
-    EXPECT_TRUE(CompareJson(result_json, ref_json));
+        const char* result_json = nullptr;
+        EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci_in, &result_json, &msg_));
+        CHECK_GEN();
+        EXPECT_TRUE(CompareJson(result_json, ref_json));
+    }
 }
 
 TEST_F(Gen, VkRenderPassCreateInfo2) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex render pass 2 layout create info JSON");
 
-    auto [ci, ref_json] = getVkRenderPassCreateInfo2(0);
+    for (auto seed : {0, 1}) {
+        auto [ci_in, ref_json] = getVkRenderPassCreateInfo2(seed);
 
-    const char* result_json = nullptr;
-
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci, &result_json, &msg_));
-    CHECK_GEN();
-    EXPECT_TRUE(CompareJson(result_json, ref_json));
+        const char* result_json = nullptr;
+        EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci_in, &result_json, &msg_));
+        CHECK_GEN();
+        EXPECT_TRUE(CompareJson(result_json, ref_json));
+    }
 }
 
 TEST_F(Gen, VkShaderModuleCreateInfo) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex shader module create info JSON");
 
-    std::string ref_json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO",
-        "pNext": "NULL",
-        "flags": 0,
-        "codeSize": 4,
-        "pCode": "GXsqCA=="
-    })"};
+    for (auto seed : {0}) {  // Test case 1 only in parser. We never generate arrays for pCode.
+        auto [ci_in, ref_json] = getVkShaderModuleCreateInfo(seed);
 
-    VkShaderModuleCreateInfo sm_ci;
-    sm_ci.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-    sm_ci.pNext = nullptr;
-    sm_ci.flags = 0;
-    sm_ci.codeSize = 4;
-
-    uint32_t code[1] = {(25 << 0) + (123 << 8) + (42 << 16) + (8 << 24)};
-    sm_ci.pCode = code;
-
-    const char* result_json = nullptr;
-
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &sm_ci, &result_json, &msg_));
-    CHECK_GEN();
-    EXPECT_TRUE(CompareJson(result_json, ref_json));
+        const char* result_json = nullptr;
+        EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci_in, &result_json, &msg_));
+        CHECK_GEN();
+        EXPECT_TRUE(CompareJson(result_json, ref_json));
+    }
 }
 
+// TODO: Use getVkDeviceObjectReservationCreateInfo once safe struct issue is resolved.
+// see: https://github.com/KhronosGroup/Vulkan-Utility-Libraries/issues/343
 TEST_F(Gen, VkDeviceObjectReservationCreateInfo) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex object reservation create info JSON");
 
@@ -354,59 +325,14 @@ TEST_F(Gen, VkDeviceObjectReservationCreateInfo) {
 TEST_F(Gen, VkPipelineOfflineCreateInfo) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex pipeline offline create info JSON");
 
-    std::string ref_json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_PIPELINE_OFFLINE_CREATE_INFO",
-        "pNext": "NULL",
-        "pipelineIdentifier": [
-        85,
-        43,
-        255,
-        24,
-        155,
-        64,
-        62,
-        24,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0
-    ],
-        "matchControl": "VK_PIPELINE_MATCH_CONTROL_APPLICATION_UUID_EXACT_MATCH",
-        "poolEntrySize": 1048576
-    })"};
+    for (auto seed : {0}) {
+        auto [ci_in, ref_json] = getVkPipelineOfflineCreateInfo(seed);
 
-    VkPipelineOfflineCreateInfo po_ci;
-
-    po_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_OFFLINE_CREATE_INFO;
-    po_ci.pNext = nullptr;
-    po_ci.pipelineIdentifier[0] = 85;
-    po_ci.pipelineIdentifier[1] = 43;
-    po_ci.pipelineIdentifier[2] = 255;
-    po_ci.pipelineIdentifier[3] = 24;
-    po_ci.pipelineIdentifier[4] = 155;
-    po_ci.pipelineIdentifier[5] = 64;
-    po_ci.pipelineIdentifier[6] = 62;
-    po_ci.pipelineIdentifier[7] = 24;
-    po_ci.pipelineIdentifier[8] = 0;
-    po_ci.pipelineIdentifier[9] = 0;
-    po_ci.pipelineIdentifier[10] = 0;
-    po_ci.pipelineIdentifier[11] = 0;
-    po_ci.pipelineIdentifier[12] = 0;
-    po_ci.pipelineIdentifier[13] = 0;
-    po_ci.pipelineIdentifier[14] = 0;
-    po_ci.pipelineIdentifier[15] = 0;
-    po_ci.matchControl = VK_PIPELINE_MATCH_CONTROL_APPLICATION_UUID_EXACT_MATCH;
-    po_ci.poolEntrySize = 1048576;
-
-    const char* result_json = nullptr;
-
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &po_ci, &result_json, &msg_));
-    CHECK_GEN();
-    EXPECT_TRUE(CompareJson(result_json, ref_json));
+        const char* result_json = nullptr;
+        EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci_in, &result_json, &msg_));
+        CHECK_GEN();
+        EXPECT_TRUE(CompareJson(result_json, ref_json));
+    }
 }
 
 TEST_F(Gen, ComputePipelineJSON) {
@@ -415,31 +341,22 @@ TEST_F(Gen, ComputePipelineJSON) {
     VpjData data{};
 
     const char* ycbcr_names[1] = {"YcbcrConversion1"};
-    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
-    auto ycbcr_conversion = VkSamplerYcbcrConversion(0);
+    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(0);
 
     const char* sampler_names[2] = {"ImmutableSampler1", "YcbcrSampler1"};
-    auto [immut_sampler_ci, immut_sampler_json] =
-        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerReductionModeCreateInfo(VK_SAMPLER_REDUCTION_MODE_MAX)));
-    auto [ycbcr_sampler_ci, ycbcr_sampler_json] =
-        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerYcbcrConversionInfo(ycbcr_conversion, ycbcr_names[0])));
+    auto [immut_sampler_ci, immut_sampler_json] = getVkSamplerCreateInfo(0);
+    auto [ycbcr_sampler_ci, ycbcr_sampler_json] = getVkSamplerCreateInfo(0, {VkSamplerYcbcrConversion(0), ycbcr_names[0]});
     VkSamplerCreateInfo sampler_ci[2] = {*immut_sampler_ci.ptr(), *ycbcr_sampler_ci.ptr()};
-    VkSampler immutableSamplers[2] = {VkSampler(0), VkSampler(1)};
 
     const char* dsl_names[1] = {"DescriptorSetLayout1"};
     auto [dsl_ci, dsl_json] =
-        getVkDescriptorSetLayoutCreateInfo(0,
-                                           {{1, VK_SHADER_STAGE_COMPUTE_BIT},
-                                            {1, VK_SHADER_STAGE_COMPUTE_BIT, immutableSamplers[0], sampler_names[0]},
-                                            {1, VK_SHADER_STAGE_COMPUTE_BIT, immutableSamplers[1], sampler_names[1]}},
-                                           std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
+        getVkDescriptorSetLayoutCreateInfo(0, {{VkSampler(0), sampler_names[0]}, {VkSampler(1), sampler_names[1]}});
 
     auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(0), dsl_names[0]}});
 
-    auto [cp_ci, cp_json] = getVkComputePipelineCreateInfo(getVkPipelineShaderStageCreateInfo(
-        0, VK_SHADER_STAGE_COMPUTE_BIT, std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo())));
+    auto [cp_ci, cp_json] = getVkComputePipelineCreateInfo(0);
 
-    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0, std::make_tuple(getVkPhysicalDeviceSynchronization2Features()));
+    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0);
 
     auto [shaderFileNames, shaderFileNames_json] = getShaderFileNames({{VK_SHADER_STAGE_COMPUTE_BIT, "shader.comp.spv"}});
 
@@ -531,38 +448,29 @@ TEST_F(Gen, GraphicsPipelineJSON) {
     VpjData data{};
 
     const char* ycbcr_names[1] = {"YcbcrConversion1"};
-    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
-    auto ycbcr_conversion = VkSamplerYcbcrConversion(0);
+    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(1);
 
     const char* sampler_names[2] = {"ImmutableSampler1", "YcbcrSampler1"};
-    auto [immut_sampler_ci, immut_sampler_json] =
-        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerReductionModeCreateInfo(VK_SAMPLER_REDUCTION_MODE_MAX)));
-    auto [ycbcr_sampler_ci, ycbcr_sampler_json] =
-        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerYcbcrConversionInfo(ycbcr_conversion, ycbcr_names[0])));
+    auto [immut_sampler_ci, immut_sampler_json] = getVkSamplerCreateInfo(1);
+    auto [ycbcr_sampler_ci, ycbcr_sampler_json] = getVkSamplerCreateInfo(1, {VkSamplerYcbcrConversion(0), ycbcr_names[0]});
     VkSamplerCreateInfo sampler_ci[2] = {*immut_sampler_ci.ptr(), *ycbcr_sampler_ci.ptr()};
-    VkSampler immutableSamplers[2] = {VkSampler(0), VkSampler(1)};
 
     const char* dsl_names[1] = {"DescriptorSetLayout1"};
     auto [dsl_ci, dsl_json] =
-        getVkDescriptorSetLayoutCreateInfo(0,
-                                           {{1, VK_SHADER_STAGE_VERTEX_BIT},
-                                            {1, VK_SHADER_STAGE_FRAGMENT_BIT, immutableSamplers[0], sampler_names[0]},
-                                            {1, VK_SHADER_STAGE_FRAGMENT_BIT, immutableSamplers[1], sampler_names[1]}},
-                                           std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
+        getVkDescriptorSetLayoutCreateInfo(1, {{VkSampler(0), sampler_names[0]}, {VkSampler(1), sampler_names[1]}});
 
-    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(0), dsl_names[0]}});
+    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(1, {{VkDescriptorSetLayout(0), dsl_names[0]}});
 
-    auto [renderPass, renderPass_json] = getVkRenderPassCreateInfo(0);
+    auto [renderPass, renderPass_json] = getVkRenderPassCreateInfo(1);
 
-    auto [gp_ci, gp_json] = getVkGraphicsPipelineCreateInfo(
-        0, {getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_VERTEX_BIT),
-            getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_FRAGMENT_BIT,
-                                               std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo()))});
+    auto [gp_ci, gp_json] = getVkGraphicsPipelineCreateInfo(1);
 
-    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0, std::make_tuple(getVkPhysicalDeviceSynchronization2Features()));
+    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(1);
 
     auto [shaderFileNames, shaderFileNames_json] = getShaderFileNames({
         {VK_SHADER_STAGE_VERTEX_BIT, "shader.vert.spv"},
+        {VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, "shader.tess_ctrl.spv"},
+        {VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, "shader.tess_eval.spv"},
         {VK_SHADER_STAGE_FRAGMENT_BIT, "shader.frag.spv"},
     });
 
@@ -657,31 +565,22 @@ TEST_F(Gen, ComputePipelineJSONWithMD5) {
     VpjData data{};
 
     const char* ycbcr_names[1] = {"YcbcrConversion1"};
-    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
-    auto ycbcr_conversion = VkSamplerYcbcrConversion(0);
+    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(0);
 
     const char* sampler_names[2] = {"ImmutableSampler1", "YcbcrSampler1"};
-    auto [immut_sampler_ci, immut_sampler_json] =
-        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerReductionModeCreateInfo(VK_SAMPLER_REDUCTION_MODE_MAX)));
-    auto [ycbcr_sampler_ci, ycbcr_sampler_json] =
-        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerYcbcrConversionInfo(ycbcr_conversion, ycbcr_names[0])));
+    auto [immut_sampler_ci, immut_sampler_json] = getVkSamplerCreateInfo(0);
+    auto [ycbcr_sampler_ci, ycbcr_sampler_json] = getVkSamplerCreateInfo(0, {VkSamplerYcbcrConversion(0), ycbcr_names[0]});
     VkSamplerCreateInfo sampler_ci[2] = {*immut_sampler_ci.ptr(), *ycbcr_sampler_ci.ptr()};
-    VkSampler immutableSamplers[2] = {VkSampler(0), VkSampler(1)};
 
     const char* dsl_names[1] = {"DescriptorSetLayout1"};
     auto [dsl_ci, dsl_json] =
-        getVkDescriptorSetLayoutCreateInfo(0,
-                                           {{1, VK_SHADER_STAGE_COMPUTE_BIT},
-                                            {1, VK_SHADER_STAGE_COMPUTE_BIT, immutableSamplers[0], sampler_names[0]},
-                                            {1, VK_SHADER_STAGE_COMPUTE_BIT, immutableSamplers[1], sampler_names[1]}},
-                                           std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
+        getVkDescriptorSetLayoutCreateInfo(0, {{VkSampler(0), sampler_names[0]}, {VkSampler(1), sampler_names[1]}});
 
     auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(0), dsl_names[0]}});
 
-    auto [cp_ci, cp_json] = getVkComputePipelineCreateInfo(getVkPipelineShaderStageCreateInfo(
-        0, VK_SHADER_STAGE_COMPUTE_BIT, std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo())));
+    auto [cp_ci, cp_json] = getVkComputePipelineCreateInfo(0);
 
-    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0, std::make_tuple(getVkPhysicalDeviceSynchronization2Features()));
+    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0);
 
     std::vector<uint32_t> ref_spirv{1, 2, 3, 4};
     auto [shaderFileNames, shaderFileNames_json] = getShaderFileNames(
@@ -750,7 +649,7 @@ TEST_F(Gen, ComputePipelineJSONWithMD5) {
         [
             "VK_EXT_robustness2"
         ],
-        "PipelineUUID" : [114, 122, 223, 248, 175, 155, 148, 173, 16, 102, 90, 164, 149, 132, 26, 51]
+        "PipelineUUID" : [192, 60, 140, 236, 89, 238, 218, 181, 232, 250, 156, 167, 106, 52, 14, 100]
     })";
     const char* result_json = nullptr;
 
@@ -767,39 +666,31 @@ TEST_F(Gen, GraphicsPipelineJSONWithMD5) {
     VpjData data{};
 
     const char* ycbcr_names[1] = {"YcbcrConversion1"};
-    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
-    auto ycbcr_conversion = VkSamplerYcbcrConversion(0);
+    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(1);
 
     const char* sampler_names[2] = {"ImmutableSampler1", "YcbcrSampler1"};
-    auto [immut_sampler_ci, immut_sampler_json] =
-        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerReductionModeCreateInfo(VK_SAMPLER_REDUCTION_MODE_MAX)));
-    auto [ycbcr_sampler_ci, ycbcr_sampler_json] =
-        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerYcbcrConversionInfo(ycbcr_conversion, ycbcr_names[0])));
+    auto [immut_sampler_ci, immut_sampler_json] = getVkSamplerCreateInfo(1);
+    auto [ycbcr_sampler_ci, ycbcr_sampler_json] = getVkSamplerCreateInfo(1, {VkSamplerYcbcrConversion(0), ycbcr_names[0]});
     VkSamplerCreateInfo sampler_ci[2] = {*immut_sampler_ci.ptr(), *ycbcr_sampler_ci.ptr()};
-    VkSampler immutableSamplers[2] = {VkSampler(0), VkSampler(1)};
 
     const char* dsl_names[1] = {"DescriptorSetLayout1"};
     auto [dsl_ci, dsl_json] =
-        getVkDescriptorSetLayoutCreateInfo(0,
-                                           {{1, VK_SHADER_STAGE_VERTEX_BIT},
-                                            {1, VK_SHADER_STAGE_FRAGMENT_BIT, immutableSamplers[0], sampler_names[0]},
-                                            {1, VK_SHADER_STAGE_FRAGMENT_BIT, immutableSamplers[1], sampler_names[1]}},
-                                           std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
+        getVkDescriptorSetLayoutCreateInfo(1, {{VkSampler(0), sampler_names[0]}, {VkSampler(1), sampler_names[1]}});
 
-    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(0), dsl_names[0]}});
+    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(1, {{VkDescriptorSetLayout(0), dsl_names[0]}});
 
-    auto [renderPass, renderPass_json] = getVkRenderPassCreateInfo(0);
+    auto [renderPass, renderPass_json] = getVkRenderPassCreateInfo(1);
 
-    auto [gp_ci, gp_json] = getVkGraphicsPipelineCreateInfo(
-        0, {getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_VERTEX_BIT),
-            getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_FRAGMENT_BIT,
-                                               std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo()))});
+    auto [gp_ci, gp_json] = getVkGraphicsPipelineCreateInfo(1);
 
-    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0, std::make_tuple(getVkPhysicalDeviceSynchronization2Features()));
+    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(1);
 
     std::vector<uint32_t> ref_spirv{1, 2, 3, 4};
     auto [shaderFileNames, shaderFileNames_json] = getShaderFileNames({
         {VK_SHADER_STAGE_VERTEX_BIT, "shader.vert.spv", ref_spirv.size() * sizeof(uint32_t), ref_spirv.data()},
+        {VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, "shader.tess_ctrl.spv", ref_spirv.size() * sizeof(uint32_t), ref_spirv.data()},
+        {VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, "shader.tess_eval.spv", ref_spirv.size() * sizeof(uint32_t),
+         ref_spirv.data()},
         {VK_SHADER_STAGE_FRAGMENT_BIT, "shader.frag.spv", ref_spirv.size() * sizeof(uint32_t), ref_spirv.data()},
     });
 
@@ -869,7 +760,7 @@ TEST_F(Gen, GraphicsPipelineJSONWithMD5) {
         [
             "VK_EXT_robustness2"
         ],
-        "PipelineUUID" : [204, 43, 222, 131, 254, 121, 127, 63, 143, 81, 2, 110, 227, 127, 168, 197]
+        "PipelineUUID" : [198, 45, 78, 88, 61, 34, 44, 163, 15, 83, 194, 0, 94, 84, 30, 19]
     })";
     const char* result_json = nullptr;
 
@@ -1259,31 +1150,22 @@ TEST_F(Gen, ZeroShaderFilenamesCompute) {
     VpjData data{};
 
     const char* ycbcr_names[1] = {"YcbcrConversion1"};
-    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
-    auto ycbcr_conversion = VkSamplerYcbcrConversion(0);
+    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(0);
 
     const char* sampler_names[2] = {"ImmutableSampler1", "YcbcrSampler1"};
-    auto [immut_sampler_ci, immut_sampler_json] =
-        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerReductionModeCreateInfo(VK_SAMPLER_REDUCTION_MODE_MAX)));
-    auto [ycbcr_sampler_ci, ycbcr_sampler_json] =
-        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerYcbcrConversionInfo(ycbcr_conversion, ycbcr_names[0])));
+    auto [immut_sampler_ci, immut_sampler_json] = getVkSamplerCreateInfo(0);
+    auto [ycbcr_sampler_ci, ycbcr_sampler_json] = getVkSamplerCreateInfo(0, {VkSamplerYcbcrConversion(0), ycbcr_names[0]});
     VkSamplerCreateInfo sampler_ci[2] = {*immut_sampler_ci.ptr(), *ycbcr_sampler_ci.ptr()};
-    VkSampler immutableSamplers[2] = {VkSampler(0), VkSampler(1)};
 
     const char* dsl_names[1] = {"DescriptorSetLayout1"};
     auto [dsl_ci, dsl_json] =
-        getVkDescriptorSetLayoutCreateInfo(0,
-                                           {{1, VK_SHADER_STAGE_COMPUTE_BIT},
-                                            {1, VK_SHADER_STAGE_COMPUTE_BIT, immutableSamplers[0], sampler_names[0]},
-                                            {1, VK_SHADER_STAGE_COMPUTE_BIT, immutableSamplers[1], sampler_names[1]}},
-                                           std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
+        getVkDescriptorSetLayoutCreateInfo(0, {{VkSampler(0), sampler_names[0]}, {VkSampler(1), sampler_names[1]}});
 
     auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(0), dsl_names[0]}});
 
-    auto [cp_ci, cp_json] = getVkComputePipelineCreateInfo(getVkPipelineShaderStageCreateInfo(
-        0, VK_SHADER_STAGE_COMPUTE_BIT, std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo())));
+    auto [cp_ci, cp_json] = getVkComputePipelineCreateInfo(0);
 
-    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0, std::make_tuple(getVkPhysicalDeviceSynchronization2Features()));
+    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0);
 
     const char* enabled_extensions[1] = {"VK_EXT_robustness2"};
 
@@ -1304,15 +1186,6 @@ TEST_F(Gen, ZeroShaderFilenamesCompute) {
     data.computePipelineState.shaderFileNameCount = 0;
     data.computePipelineState.pShaderFileNames = nullptr;
 
-    data.pipelineUUID[0] = 85;
-    data.pipelineUUID[1] = 43;
-    data.pipelineUUID[2] = 255;
-    data.pipelineUUID[3] = 24;
-    data.pipelineUUID[4] = 155;
-    data.pipelineUUID[5] = 64;
-    data.pipelineUUID[6] = 62;
-    data.pipelineUUID[7] = 24;
-
     const char* result_json = nullptr;
 
     EXPECT_FALSE(vpjGeneratePipelineJson(generator_, &data, &result_json, &msg_));
@@ -1324,35 +1197,24 @@ TEST_F(Gen, ZeroShaderFilenamesGraphics) {
     VpjData data{};
 
     const char* ycbcr_names[1] = {"YcbcrConversion1"};
-    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
-    auto ycbcr_conversion = VkSamplerYcbcrConversion(0);
+    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(1);
 
     const char* sampler_names[2] = {"ImmutableSampler1", "YcbcrSampler1"};
-    auto [immut_sampler_ci, immut_sampler_json] =
-        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerReductionModeCreateInfo(VK_SAMPLER_REDUCTION_MODE_MAX)));
-    auto [ycbcr_sampler_ci, ycbcr_sampler_json] =
-        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerYcbcrConversionInfo(ycbcr_conversion, ycbcr_names[0])));
+    auto [immut_sampler_ci, immut_sampler_json] = getVkSamplerCreateInfo(1);
+    auto [ycbcr_sampler_ci, ycbcr_sampler_json] = getVkSamplerCreateInfo(1, {VkSamplerYcbcrConversion(0), ycbcr_names[0]});
     VkSamplerCreateInfo sampler_ci[2] = {*immut_sampler_ci.ptr(), *ycbcr_sampler_ci.ptr()};
-    VkSampler immutableSamplers[2] = {VkSampler(0), VkSampler(1)};
 
     const char* dsl_names[1] = {"DescriptorSetLayout1"};
     auto [dsl_ci, dsl_json] =
-        getVkDescriptorSetLayoutCreateInfo(0,
-                                           {{1, VK_SHADER_STAGE_VERTEX_BIT},
-                                            {1, VK_SHADER_STAGE_FRAGMENT_BIT, immutableSamplers[0], sampler_names[0]},
-                                            {1, VK_SHADER_STAGE_FRAGMENT_BIT, immutableSamplers[1], sampler_names[1]}},
-                                           std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
+        getVkDescriptorSetLayoutCreateInfo(1, {{VkSampler(0), sampler_names[0]}, {VkSampler(1), sampler_names[1]}});
 
-    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(0), dsl_names[0]}});
+    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(1, {{VkDescriptorSetLayout(0), dsl_names[0]}});
 
-    auto [renderPass, renderPass_json] = getVkRenderPassCreateInfo(0);
+    auto [renderPass, renderPass_json] = getVkRenderPassCreateInfo(1);
 
-    auto [gp_ci, gp_json] = getVkGraphicsPipelineCreateInfo(
-        0, {getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_VERTEX_BIT),
-            getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_FRAGMENT_BIT,
-                                               std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo()))});
+    auto [gp_ci, gp_json] = getVkGraphicsPipelineCreateInfo(1);
 
-    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0, std::make_tuple(getVkPhysicalDeviceSynchronization2Features()));
+    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(1);
 
     const char* enabled_extensions[1] = {"VK_EXT_robustness2"};
 
@@ -1373,15 +1235,6 @@ TEST_F(Gen, ZeroShaderFilenamesGraphics) {
     data.graphicsPipelineState.pPhysicalDeviceFeatures = &pdf;
     data.graphicsPipelineState.shaderFileNameCount = 0;
     data.graphicsPipelineState.pShaderFileNames = nullptr;
-
-    data.pipelineUUID[0] = 85;
-    data.pipelineUUID[1] = 43;
-    data.pipelineUUID[2] = 255;
-    data.pipelineUUID[3] = 24;
-    data.pipelineUUID[4] = 155;
-    data.pipelineUUID[5] = 64;
-    data.pipelineUUID[6] = 62;
-    data.pipelineUUID[7] = 24;
 
     const char* result_json = nullptr;
 

--- a/tests/pcjson/pcjson_test_gen.cpp
+++ b/tests/pcjson/pcjson_test_gen.cpp
@@ -7,6 +7,7 @@
 
 #include <vulkan/pcjson/vksc_pipeline_json.h>
 #include <vulkan/utility/vk_struct_helper.hpp>
+#include <vulkan/utility/vk_safe_struct.hpp>
 #include <vulkan/vulkan_sc.h>
 
 #include <gtest/gtest.h>
@@ -22,6 +23,9 @@
 #include <json/json.h>
 
 #include "json_validator.h"
+#include "json_struct_helpers.h"
+
+using namespace std::string_literals;
 
 class Gen : public testing::Test {
   public:
@@ -52,122 +56,8 @@ class Gen : public testing::Test {
 TEST_F(Gen, VkPhysicalDeviceFeatures2) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex physical device features 2 JSON");
 
-    std::string ref_json = {R"({
-        "sType": "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2",
-        "pNext": {
-            "sType": "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES",
-            "pNext": {
-                "sType": "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES",
-                "pNext": "NULL",
-                "scalarBlockLayout": "VK_TRUE"
-            },
-            "storageBuffer16BitAccess": "VK_FALSE",
-            "uniformAndStorageBuffer16BitAccess": "VK_FALSE",
-            "storagePushConstant16": "VK_FALSE",
-            "storageInputOutput16": "VK_FALSE",
-            "multiview": "VK_FALSE",
-            "multiviewGeometryShader": "VK_FALSE",
-            "multiviewTessellationShader": "VK_FALSE",
-            "variablePointersStorageBuffer": "VK_FALSE",
-            "variablePointers": "VK_FALSE",
-            "protectedMemory": "VK_FALSE",
-            "samplerYcbcrConversion": "VK_TRUE",
-            "shaderDrawParameters": "VK_FALSE"
-        },
-)"
-                            R"(
-        "features": {
-            "robustBufferAccess": "VK_FALSE",
-            "fullDrawIndexUint32" : "VK_TRUE",
-            "imageCubeArray" : "VK_FALSE",
-            "independentBlend" : "VK_TRUE",
-            "geometryShader" : "VK_FALSE",
-            "tessellationShader" : "VK_TRUE",
-            "sampleRateShading" : "VK_FALSE",
-            "dualSrcBlend" : "VK_TRUE",
-            "logicOp" : "VK_FALSE",
-            "multiDrawIndirect" : "VK_TRUE",
-            "drawIndirectFirstInstance" : "VK_FALSE",
-            "depthClamp" : "VK_FALSE",
-            "depthBiasClamp" : "VK_TRUE",
-            "fillModeNonSolid" : "VK_FALSE",
-            "depthBounds" : "VK_TRUE",
-            "wideLines" : "VK_FALSE",
-            "largePoints" : "VK_TRUE",
-            "alphaToOne" : "VK_FALSE",
-            "multiViewport" : "VK_TRUE",
-            "samplerAnisotropy" : "VK_FALSE",
-            "textureCompressionETC2" : "VK_TRUE",
-            "textureCompressionASTC_LDR" : "VK_FALSE",
-            "textureCompressionBC" : "VK_TRUE",
-            "occlusionQueryPrecise" : "VK_FALSE",
-            "pipelineStatisticsQuery" : "VK_TRUE",
-            "vertexPipelineStoresAndAtomics" : "VK_FALSE",
-            "fragmentStoresAndAtomics" : "VK_FALSE",
-            "shaderTessellationAndGeometryPointSize" : "VK_TRUE",
-            "shaderImageGatherExtended" : "VK_FALSE",
-            "shaderStorageImageExtendedFormats" : "VK_TRUE",
-            "shaderStorageImageMultisample" : "VK_FALSE",
-            "shaderStorageImageReadWithoutFormat" : "VK_TRUE",
-            "shaderStorageImageWriteWithoutFormat" : "VK_FALSE",
-            "shaderUniformBufferArrayDynamicIndexing" : "VK_TRUE",
-            "shaderSampledImageArrayDynamicIndexing" : "VK_FALSE",
-            "shaderStorageBufferArrayDynamicIndexing" : "VK_TRUE",
-            "shaderStorageImageArrayDynamicIndexing" : "VK_FALSE",
-            "shaderClipDistance" : "VK_TRUE",
-            "shaderCullDistance" : "VK_FALSE",
-            "shaderFloat64" : "VK_TRUE",
-            "shaderInt64" : "VK_FALSE",
-            "shaderInt16" : "VK_TRUE",
-            "shaderResourceResidency" : "VK_FALSE",
-            "shaderResourceMinLod" : "VK_TRUE",
-            "sparseBinding" : "VK_FALSE",
-            "sparseResidencyBuffer" : "VK_TRUE",
-            "sparseResidencyImage2D" : "VK_FALSE",
-            "sparseResidencyImage3D" : "VK_TRUE",
-            "sparseResidency2Samples" : "VK_FALSE",
-            "sparseResidency4Samples" : "VK_TRUE",
-            "sparseResidency8Samples" : "VK_FALSE",
-            "sparseResidency16Samples" : "VK_TRUE",
-            "sparseResidencyAliased" : "VK_FALSE",
-            "variableMultisampleRate" : "VK_TRUE",
-            "inheritedQueries" : "VK_FALSE"
-        }
-    })"};
-
-    auto sblf = vku::InitStruct<VkPhysicalDeviceScalarBlockLayoutFeatures>();
-    sblf.scalarBlockLayout = VK_TRUE;
-
-    auto vk11f = vku::InitStruct<VkPhysicalDeviceVulkan11Features>(&sblf);
-    vk11f.samplerYcbcrConversion = VK_TRUE;
-
-    auto pdf = vku::InitStruct<VkPhysicalDeviceFeatures2>(&vk11f);
-    pdf.features.fullDrawIndexUint32 = VK_TRUE;
-    pdf.features.independentBlend = VK_TRUE;
-    pdf.features.tessellationShader = VK_TRUE;
-    pdf.features.dualSrcBlend = VK_TRUE;
-    pdf.features.multiDrawIndirect = VK_TRUE;
-    pdf.features.depthBiasClamp = VK_TRUE;
-    pdf.features.depthBounds = VK_TRUE;
-    pdf.features.largePoints = VK_TRUE;
-    pdf.features.multiViewport = VK_TRUE;
-    pdf.features.textureCompressionETC2 = VK_TRUE;
-    pdf.features.textureCompressionBC = VK_TRUE;
-    pdf.features.pipelineStatisticsQuery = VK_TRUE;
-    pdf.features.shaderTessellationAndGeometryPointSize = VK_TRUE;
-    pdf.features.shaderStorageImageExtendedFormats = VK_TRUE;
-    pdf.features.shaderStorageImageReadWithoutFormat = VK_TRUE;
-    pdf.features.shaderUniformBufferArrayDynamicIndexing = VK_TRUE;
-    pdf.features.shaderStorageBufferArrayDynamicIndexing = VK_TRUE;
-    pdf.features.shaderClipDistance = VK_TRUE;
-    pdf.features.shaderFloat64 = VK_TRUE;
-    pdf.features.shaderInt16 = VK_TRUE;
-    pdf.features.shaderResourceMinLod = VK_TRUE;
-    pdf.features.sparseResidencyBuffer = VK_TRUE;
-    pdf.features.sparseResidencyImage3D = VK_TRUE;
-    pdf.features.sparseResidency4Samples = VK_TRUE;
-    pdf.features.sparseResidency16Samples = VK_TRUE;
-    pdf.features.variableMultisampleRate = VK_TRUE;
+    auto [pdf, ref_json] = getVkPhysicalDeviceFeatures2(
+        0, std::make_tuple(getVkPhysicalDeviceVulkan11Features(), getVkPhysicalDeviceScalarBlockLayoutFeatures()));
 
     const char* result_json = nullptr;
 
@@ -179,480 +69,19 @@ TEST_F(Gen, VkPhysicalDeviceFeatures2) {
 TEST_F(Gen, VkGraphicsPipelineCreateInfo) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex graphics pipeline create info JSON");
 
-    const char* ref_json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO",
-        "pNext": {
-            "sType": "VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT",
-            "pNext" : "NULL",
-            "flags": 0,
-            "discardRectangleMode": "VK_DISCARD_RECTANGLE_MODE_EXCLUSIVE_EXT",
-            "discardRectangleCount": 1,
-            "pDiscardRectangles": [
-                {
-                    "offset":
-                    {
-                        "x" : 0,
-                        "y" : 0
-                    },
-                    "extent":
-                    {
-                        "width" : 51,
-                        "height" : 51
-                    }
-                }
-            ]
-        },
-        "flags" : 0,
-        "stageCount" : 5,
-        "pStages": 
-        [
-        {
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-            "pNext":"NULL",
-            "flags" : 0,
-            "stage" : "VK_SHADER_STAGE_VERTEX_BIT",
-            "module" : 35,
-            "pName" : "main",
-            "pSpecializationInfo": 
-            "NULL"
-        },
-        {
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-            "pNext":"NULL",
-            "flags" : 0,
-            "stage" : "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
-            "module" : 36,
-            "pName" : "main",
-            "pSpecializationInfo": 
-            "NULL"
-        },
-        {
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-            "pNext":"NULL",
-            "flags" : 0,
-            "stage" : "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
-            "module" : 37,
-            "pName" : "main",
-            "pSpecializationInfo": 
-            "NULL"
-        },
-        {
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-            "pNext":"NULL",
-            "flags" : 0,
-            "stage" : "VK_SHADER_STAGE_GEOMETRY_BIT",
-            "module" : 38,
-            "pName" : "main",
-            "pSpecializationInfo": 
-            "NULL"
-        },
-        {
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-            "pNext":"NULL",
-            "flags" : 0,
-            "stage" : "VK_SHADER_STAGE_FRAGMENT_BIT",
-            "module" : 39,
-            "pName" : "main",
-            "pSpecializationInfo": 
-            "NULL"
-        }
-        ],
-)"
-                            R"(
-        "pVertexInputState": 
-        {
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO",
-            "pNext":"NULL",
-            "flags" : 0,
-            "vertexBindingDescriptionCount" : 1,
-            "pVertexBindingDescriptions": 
-            [
-            {
-                "binding" : 0,
-                "stride" : 32,
-                "inputRate" : "VK_VERTEX_INPUT_RATE_VERTEX"
-            }
-            ],
-            "vertexAttributeDescriptionCount" : 2,
-            "pVertexAttributeDescriptions": 
-            [
-            {
-                "location" : 0,
-                "binding" : 0,
-                "format" : "VK_FORMAT_R32G32B32A32_SFLOAT",
-                "offset" : 0
-            },
-            {
-                "location" : 1,
-                "binding" : 0,
-                "format" : "VK_FORMAT_R32G32B32A32_SFLOAT",
-                "offset" : 16
-            }
-            ]
-        },
-        "pInputAssemblyState": 
-        {
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO",
-            "pNext":"NULL",
-            "flags" : 0,
-            "topology" : "VK_PRIMITIVE_TOPOLOGY_PATCH_LIST",
-            "primitiveRestartEnable" : "VK_FALSE"
-        },
-        "pTessellationState": 
-        {
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO",
-            "pNext":"NULL",
-            "flags" : 0,
-            "patchControlPoints" : 4
-        },
-)"
-                            R"(
-        "pViewportState": 
-        {
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO",
-            "pNext":"NULL",
-            "flags" : 0,
-            "viewportCount" : 1,
-            "pViewports": 
-            [
-            {
-                "x" : 0.0,
-                "y" : 0.0,
-                "width" : 51.0,
-                "height" : 51.0,
-                "minDepth" : 0.0,
-                "maxDepth" : 1.0
-            }
-            ],
-            "scissorCount" : 1,
-            "pScissors": 
-            [
-            {
-                "offset": 
-                {
-                    "x" : 0,
-                    "y" : 0
-                },
-                "extent": 
-                {
-                    "width" : 51,
-                    "height" : 51
-                }
-            }
-            ]
-        },
-        "pRasterizationState": 
-        {
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO",
-            "pNext":"NULL",
-            "flags" : 0,
-            "depthClampEnable" : "VK_FALSE",
-            "rasterizerDiscardEnable" : "VK_FALSE",
-            "polygonMode" : "VK_POLYGON_MODE_FILL",
-            "cullMode" : 0,
-            "frontFace" : "VK_FRONT_FACE_COUNTER_CLOCKWISE",
-            "depthBiasEnable" : "VK_FALSE",
-            "depthBiasConstantFactor" : 0.0,
-            "depthBiasClamp" : 0.0,
-            "depthBiasSlopeFactor" : 0.0,
-            "lineWidth" : 1.0
-        },
-        "pMultisampleState": 
-        {
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO",
-            "pNext":"NULL",
-            "flags" : 0,
-            "rasterizationSamples" : "VK_SAMPLE_COUNT_1_BIT",
-            "sampleShadingEnable" : "VK_FALSE",
-            "minSampleShading" : 1.0,
-            "pSampleMask":
-            "NULL",
-            "alphaToCoverageEnable" : "VK_FALSE",
-            "alphaToOneEnable" : "VK_FALSE"
-        },
-)"
-                            R"(
-        "pDepthStencilState": 
-        {
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO",
-            "pNext":"NULL",
-            "flags" : 0,
-            "depthTestEnable" : "VK_TRUE",
-            "depthWriteEnable" : "VK_TRUE",
-            "depthCompareOp" : "VK_COMPARE_OP_LESS_OR_EQUAL",
-            "depthBoundsTestEnable" : "VK_FALSE",
-            "stencilTestEnable" : "VK_FALSE",
-            "front": 
-            {
-                "failOp" : "VK_STENCIL_OP_KEEP",
-                "passOp" : "VK_STENCIL_OP_KEEP",
-                "depthFailOp" : "VK_STENCIL_OP_KEEP",
-                "compareOp" : "VK_COMPARE_OP_NEVER",
-                "compareMask" : 0,
-                "writeMask" : 0,
-                "reference" : 0
-            },
-            "back": 
-            {
-                "failOp" : "VK_STENCIL_OP_KEEP",
-                "passOp" : "VK_STENCIL_OP_KEEP",
-                "depthFailOp" : "VK_STENCIL_OP_KEEP",
-                "compareOp" : "VK_COMPARE_OP_NEVER",
-                "compareMask" : 0,
-                "writeMask" : 0,
-                "reference" : 0
-            },
-            "minDepthBounds" : 0.0,
-            "maxDepthBounds" : 1.0
-        },
-        "pColorBlendState": 
-        {
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO",
-            "pNext":"NULL",
-            "flags" : 0,
-            "logicOpEnable" : "VK_FALSE",
-            "logicOp" : "VK_LOGIC_OP_CLEAR",
-            "attachmentCount" : 1,
-            "pAttachments": 
-            [
-            {
-                "blendEnable" : "VK_FALSE",
-                "srcColorBlendFactor" : "VK_BLEND_FACTOR_ZERO",
-                "dstColorBlendFactor" : "VK_BLEND_FACTOR_ZERO",
-                "colorBlendOp" : "VK_BLEND_OP_ADD",
-                "srcAlphaBlendFactor" : "VK_BLEND_FACTOR_ZERO",
-                "dstAlphaBlendFactor" : "VK_BLEND_FACTOR_ZERO",
-                "alphaBlendOp" : "VK_BLEND_OP_ADD",
-                "colorWriteMask" : "VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT"
-            }
-            ],
-            "blendConstants":
-            [
-            0.0,
-            0.0,
-            0.0,
-            0.0
-            ]
-        },
-        "pDynamicState": "NULL",
-        "layout" : 8,
-        "renderPass" : 6,
-        "subpass" : 0,
-        "basePipelineHandle" : "",
-        "basePipelineIndex" : 0
-    })"};
-
-    VkGraphicsPipelineCreateInfo gp_ci{};
-
-    VkPipelineDiscardRectangleStateCreateInfoEXT pdrs_ci{};
-    VkPipelineVertexInputStateCreateInfo pvis_ci{};
-    VkPipelineInputAssemblyStateCreateInfo pias_ci{};
-    VkPipelineTessellationStateCreateInfo pts_ci{};
-    VkPipelineViewportStateCreateInfo pvs_ci{};
-    VkPipelineRasterizationStateCreateInfo prs_ci{};
-    VkPipelineMultisampleStateCreateInfo pmss_ci{};
-    VkPipelineDepthStencilStateCreateInfo pdss_ci{};
-    VkPipelineColorBlendStateCreateInfo pcbs_ci{};
-
-    gp_ci.pNext = &pdrs_ci;
-    gp_ci.pVertexInputState = &pvis_ci;
-    gp_ci.pInputAssemblyState = &pias_ci;
-    gp_ci.pTessellationState = &pts_ci;
-    gp_ci.pViewportState = &pvs_ci;
-    gp_ci.pRasterizationState = &prs_ci;
-    gp_ci.pMultisampleState = &pmss_ci;
-    gp_ci.pDepthStencilState = &pdss_ci;
-    gp_ci.pColorBlendState = &pcbs_ci;
-
-    gp_ci.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    pdrs_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT;
-    pdrs_ci.pNext = nullptr;
-    pdrs_ci.flags = 0;
-    pdrs_ci.discardRectangleMode = VK_DISCARD_RECTANGLE_MODE_EXCLUSIVE_EXT;
-
-    VkRect2D discardRectangles[1] = {};
-    pdrs_ci.discardRectangleCount = 1;
-    pdrs_ci.pDiscardRectangles = discardRectangles;
-    discardRectangles[0].offset.y = 0;
-    discardRectangles[0].extent.width = 51;
-    discardRectangles[0].extent.height = 51;
-    discardRectangles[0].offset.x = 0;
-
-    gp_ci.flags = 0;
-
-    VkPipelineShaderStageCreateInfo stages[5] = {};
-    gp_ci.stageCount = 5;
-    gp_ci.pStages = stages;
-
-    stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    stages[0].pNext = nullptr;
-    stages[0].flags = 0;
-    stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-    stages[0].module = reinterpret_cast<VkShaderModule>(35);
-    stages[0].pName = "main";
-    stages[0].pSpecializationInfo = nullptr;
-    stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    stages[1].pNext = nullptr;
-    stages[1].flags = 0;
-    stages[1].stage = VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
-    stages[1].module = reinterpret_cast<VkShaderModule>(36);
-    stages[1].pName = "main";
-    stages[1].pSpecializationInfo = nullptr;
-    stages[2].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    stages[2].pNext = nullptr;
-    stages[2].flags = 0;
-    stages[2].stage = VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
-    stages[2].module = reinterpret_cast<VkShaderModule>(37);
-    stages[2].pName = "main";
-    stages[2].pSpecializationInfo = nullptr;
-    stages[3].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    stages[3].pNext = nullptr;
-    stages[3].flags = 0;
-    stages[3].stage = VK_SHADER_STAGE_GEOMETRY_BIT;
-    stages[3].module = reinterpret_cast<VkShaderModule>(38);
-    stages[3].pName = "main";
-    stages[3].pSpecializationInfo = nullptr;
-    stages[4].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    stages[4].pNext = nullptr;
-    stages[4].flags = 0;
-    stages[4].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    stages[4].module = reinterpret_cast<VkShaderModule>(39);
-    stages[4].pName = "main";
-    stages[4].pSpecializationInfo = nullptr;
-
-    pvis_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
-    pvis_ci.pNext = nullptr;
-    pvis_ci.flags = 0;
-
-    VkVertexInputBindingDescription vertex_binding_desc[1] = {};
-    pvis_ci.vertexBindingDescriptionCount = 1;
-    pvis_ci.pVertexBindingDescriptions = vertex_binding_desc;
-    vertex_binding_desc[0].stride = 32;
-    vertex_binding_desc[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
-    vertex_binding_desc[0].binding = 0;
-
-    VkVertexInputAttributeDescription vertex_attrib_desc[2] = {};
-    pvis_ci.vertexAttributeDescriptionCount = 2;
-    pvis_ci.pVertexAttributeDescriptions = vertex_attrib_desc;
-    vertex_attrib_desc[0].location = 0;
-    vertex_attrib_desc[0].binding = 0;
-    vertex_attrib_desc[0].format = VK_FORMAT_R32G32B32A32_SFLOAT;
-    vertex_attrib_desc[0].offset = 0;
-    vertex_attrib_desc[1].location = 1;
-    vertex_attrib_desc[1].binding = 0;
-    vertex_attrib_desc[1].format = VK_FORMAT_R32G32B32A32_SFLOAT;
-    vertex_attrib_desc[1].offset = 16;
-
-    pias_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
-    pias_ci.pNext = nullptr;
-    pias_ci.flags = 0;
-    pias_ci.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
-    pias_ci.primitiveRestartEnable = VK_FALSE;
-    pts_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO;
-    pts_ci.pNext = nullptr;
-    pts_ci.flags = 0;
-    pts_ci.patchControlPoints = 4;
-    pvs_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
-    pvs_ci.pNext = nullptr;
-    pvs_ci.flags = 0;
-
-    VkViewport viewports[1] = {};
-    pvs_ci.viewportCount = 1;
-    pvs_ci.pViewports = viewports;
-    viewports[0].y = 0;
-    viewports[0].width = 51;
-    viewports[0].height = 51;
-    viewports[0].x = 0;
-    viewports[0].minDepth = 0;
-    viewports[0].maxDepth = 1;
-
-    VkRect2D scissors[1] = {};
-    pvs_ci.scissorCount = 1;
-    pvs_ci.pScissors = scissors;
-    scissors[0].offset.x = 0;
-    scissors[0].offset.y = 0;
-    scissors[0].extent.width = 51;
-    scissors[0].extent.height = 51;
-
-    prs_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
-    prs_ci.pNext = nullptr;
-    prs_ci.flags = 0;
-    prs_ci.depthClampEnable = VK_FALSE;
-    prs_ci.rasterizerDiscardEnable = VK_FALSE;
-    prs_ci.polygonMode = VK_POLYGON_MODE_FILL;
-    prs_ci.cullMode = 0;
-    prs_ci.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
-    prs_ci.depthBiasEnable = VK_FALSE;
-    prs_ci.depthBiasConstantFactor = 0;
-    prs_ci.depthBiasClamp = 0;
-    prs_ci.depthBiasSlopeFactor = 0;
-    prs_ci.lineWidth = 1;
-    pmss_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
-    pmss_ci.pNext = nullptr;
-    pmss_ci.flags = 0;
-    pmss_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
-    pmss_ci.sampleShadingEnable = VK_FALSE;
-    pmss_ci.minSampleShading = 1;
-    pmss_ci.pSampleMask = nullptr;
-    pmss_ci.alphaToCoverageEnable = VK_FALSE;
-    pmss_ci.alphaToOneEnable = VK_FALSE;
-    pdss_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
-    pdss_ci.pNext = nullptr;
-    pdss_ci.flags = 0;
-    pdss_ci.depthTestEnable = VK_TRUE;
-    pdss_ci.depthWriteEnable = VK_TRUE;
-    pdss_ci.depthCompareOp = VK_COMPARE_OP_LESS_OR_EQUAL;
-    pdss_ci.depthBoundsTestEnable = VK_FALSE;
-    pdss_ci.stencilTestEnable = VK_FALSE;
-    pdss_ci.front.failOp = VK_STENCIL_OP_KEEP;
-    pdss_ci.front.passOp = VK_STENCIL_OP_KEEP;
-    pdss_ci.front.depthFailOp = VK_STENCIL_OP_KEEP;
-    pdss_ci.front.compareOp = VK_COMPARE_OP_NEVER;
-    pdss_ci.front.compareMask = 0;
-    pdss_ci.front.writeMask = 0;
-    pdss_ci.front.reference = 0;
-    pdss_ci.back.failOp = VK_STENCIL_OP_KEEP;
-    pdss_ci.back.passOp = VK_STENCIL_OP_KEEP;
-    pdss_ci.back.depthFailOp = VK_STENCIL_OP_KEEP;
-    pdss_ci.back.compareOp = VK_COMPARE_OP_NEVER;
-    pdss_ci.back.compareMask = 0;
-    pdss_ci.back.writeMask = 0;
-    pdss_ci.back.reference = 0;
-    pdss_ci.minDepthBounds = 0;
-    pdss_ci.maxDepthBounds = 1;
-    pcbs_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
-    pcbs_ci.pNext = nullptr;
-    pcbs_ci.flags = 0;
-    pcbs_ci.logicOpEnable = VK_FALSE;
-    pcbs_ci.logicOp = VK_LOGIC_OP_CLEAR;
-
-    VkPipelineColorBlendAttachmentState attachments[1] = {};
-    pcbs_ci.attachmentCount = 1;
-    pcbs_ci.pAttachments = attachments;
-    attachments[0].blendEnable = VK_FALSE;
-    attachments[0].srcColorBlendFactor = VK_BLEND_FACTOR_ZERO;
-    attachments[0].dstColorBlendFactor = VK_BLEND_FACTOR_ZERO;
-    attachments[0].colorBlendOp = VK_BLEND_OP_ADD;
-    attachments[0].srcAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
-    attachments[0].dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
-    attachments[0].alphaBlendOp = VK_BLEND_OP_ADD;
-    attachments[0].colorWriteMask =
-        VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
-
-    pcbs_ci.blendConstants[0] = 0;
-    pcbs_ci.blendConstants[1] = 0;
-    pcbs_ci.blendConstants[2] = 0;
-    pcbs_ci.blendConstants[3] = 0;
-    gp_ci.pDynamicState = nullptr;
-    gp_ci.layout = reinterpret_cast<VkPipelineLayout>(8);
-    gp_ci.renderPass = reinterpret_cast<VkRenderPass>(6);
-    gp_ci.subpass = 0;
-    gp_ci.basePipelineHandle = VK_NULL_HANDLE;
-    gp_ci.basePipelineIndex = 0;
+    auto [ci, ref_json] = getVkGraphicsPipelineCreateInfo(
+        0,
+        {getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_VERTEX_BIT),
+         getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT),
+         getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT,
+                                            std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo())),
+         getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_GEOMETRY_BIT),
+         getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_FRAGMENT_BIT)},
+        std::make_tuple(getVkPipelineDiscardRectangleStateCreateInfoEXT()));
 
     const char* result_json = nullptr;
 
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &gp_ci, &result_json, &msg_));
+    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci, &result_json, &msg_));
     CHECK_GEN();
     EXPECT_TRUE(CompareJson(result_json, ref_json));
 }
@@ -660,80 +89,12 @@ TEST_F(Gen, VkGraphicsPipelineCreateInfo) {
 TEST_F(Gen, VkComputePipelineCreateInfo) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex compute pipeline create info JSON");
 
-    std::string ref_json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO",
-        "pNext": "NULL",
-        "flags" : 0,
-        "stage":
-        {
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-            "pNext": {
-                "sType": "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO",
-                "pNext": "NULL",
-                "requiredSubgroupSize": 64
-            },
-            "flags" : "VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT",
-            "stage" : "VK_SHADER_STAGE_COMPUTE_BIT",
-            "pName" : "main",
-            "pSpecializationInfo": {
-                "mapEntryCount": 1,
-                "pMapEntries": [
-                    {
-                        "constantID": 0,
-                        "offset": 0,
-                        "size": 4
-                    }
-                ],
-                "dataSize": 4,
-                "pData": "AAECAw=="
-            },
-            "module": ""
-        },
-        "layout" : 9,
-        "basePipelineHandle" : "",
-        "basePipelineIndex" : 0
-    })"};
-
-    VkComputePipelineCreateInfo cp_ci{};
-    cp_ci.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
-    cp_ci.pNext = nullptr;
-    cp_ci.flags = 0;
-    cp_ci.stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-
-    VkPipelineShaderStageRequiredSubgroupSizeCreateInfo pssrss_ci{};
-    pssrss_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO;
-    pssrss_ci.pNext = nullptr;
-    pssrss_ci.requiredSubgroupSize = 64;
-    cp_ci.stage.pNext = &pssrss_ci;
-
-    cp_ci.stage.flags = VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT;
-    cp_ci.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    cp_ci.stage.pName = "main";
-
-    VkSpecializationInfo specializationInfo{};
-
-    VkSpecializationMapEntry specializationMapEntries[1] = {};
-    specializationInfo.mapEntryCount = 1;
-
-    specializationMapEntries[0].constantID = 0;
-    specializationMapEntries[0].offset = 0;
-    specializationMapEntries[0].size = 4;
-    specializationInfo.pMapEntries = specializationMapEntries;
-
-    uint8_t specializationData[4] = {0, 1, 2, 3};
-    specializationInfo.dataSize = 4;
-
-    specializationInfo.pData = specializationData;
-
-    cp_ci.stage.pSpecializationInfo = &specializationInfo;
-    cp_ci.stage.module = VK_NULL_HANDLE;
-    cp_ci.layout = reinterpret_cast<VkPipelineLayout>(9);
-    cp_ci.basePipelineHandle = VK_NULL_HANDLE;
-    cp_ci.basePipelineIndex = 0;
+    auto [ci, ref_json] = getVkComputePipelineCreateInfo(getVkPipelineShaderStageCreateInfo(
+        0, VK_SHADER_STAGE_COMPUTE_BIT, std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo())));
 
     const char* result_json = nullptr;
 
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &cp_ci, &result_json, &msg_));
+    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci, &result_json, &msg_));
     CHECK_GEN();
     EXPECT_TRUE(CompareJson(result_json, ref_json));
 }
@@ -741,61 +102,11 @@ TEST_F(Gen, VkComputePipelineCreateInfo) {
 TEST_F(Gen, VkSamplerYcbcrConversionCreateInfo) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex ycbcr conversion create info JSON");
 
-#ifdef VK_USE_PLATFORM_SCREEN_QNX
-    std::string ycbcr_ci_pnext = R"({
-            "sType" : "VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_QNX",
-            "pNext": "NULL",
-            "externalFormat": 10
-    })";
-#else
-    std::string ycbcr_ci_pnext = R"("NULL")";
-#endif  // VK_USE_PLATFORM_SCREEN_QNX
-
-    std::string ref_json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO",
-        "pNext": )" + ycbcr_ci_pnext +
-                            R"(,
-        "format": "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16",
-        "ycbcrModel": "VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020",
-        "ycbcrRange": "VK_SAMPLER_YCBCR_RANGE_ITU_NARROW",
-        "components": {
-            "r": "VK_COMPONENT_SWIZZLE_A",
-            "g": "VK_COMPONENT_SWIZZLE_B",
-            "b": "VK_COMPONENT_SWIZZLE_G",
-            "a": "VK_COMPONENT_SWIZZLE_R",
-        },
-        "xChromaOffset": "VK_CHROMA_LOCATION_COSITED_EVEN",
-        "yChromaOffset": "VK_CHROMA_LOCATION_MIDPOINT",
-        "chromaFilter": "VK_FILTER_CUBIC_EXT",
-        "forceExplicitReconstruction": "VK_TRUE"
-    })"};
-
-    VkSamplerYcbcrConversionCreateInfo ycbcr_ci;
-    ycbcr_ci.sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO;
-#ifdef VK_USE_PLATFORM_SCREEN_QNX
-    VkExternalFormatQNX ef_qnx{};
-    ef_qnx.sType = VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_QNX;
-    ef_qnx.pNext = nullptr;
-    ef_qnx.externalFormat = 10;
-    ycbcr_ci.pNext = &ef_qnx;
-#else
-    ycbcr_ci.pNext = nullptr;
-#endif  // VK_USE_PLATFORM_SCREEN_QNX
-    ycbcr_ci.format = VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16;
-    ycbcr_ci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020;
-    ycbcr_ci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_NARROW;
-    ycbcr_ci.components.r = VK_COMPONENT_SWIZZLE_A;
-    ycbcr_ci.components.g = VK_COMPONENT_SWIZZLE_B;
-    ycbcr_ci.components.b = VK_COMPONENT_SWIZZLE_G;
-    ycbcr_ci.components.a = VK_COMPONENT_SWIZZLE_R;
-    ycbcr_ci.xChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
-    ycbcr_ci.yChromaOffset = VK_CHROMA_LOCATION_MIDPOINT;
-    ycbcr_ci.chromaFilter = VK_FILTER_CUBIC_EXT;
-    ycbcr_ci.forceExplicitReconstruction = VK_TRUE;
+    auto [ci, ref_json] = getVkSamplerYcbcrConversionCreateInfo();
 
     const char* result_json = nullptr;
 
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ycbcr_ci, &result_json, &msg_));
+    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci, &result_json, &msg_));
     CHECK_GEN();
     EXPECT_TRUE(CompareJson(result_json, ref_json));
 }
@@ -803,119 +114,40 @@ TEST_F(Gen, VkSamplerYcbcrConversionCreateInfo) {
 TEST_F(Gen, VkSamplerCreateInfo) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex sampler create info JSON");
 
-    std::string ref_json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO",
-        "pNext": {
-            "sType" : "VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO",
-            "pNext": "NULL",
-            "reductionMode": "VK_SAMPLER_REDUCTION_MODE_MAX"
-        },
-        "flags": 0,
-        "magFilter": "VK_FILTER_CUBIC_EXT",
-        "minFilter": "VK_FILTER_NEAREST",
-        "mipmapMode": "VK_SAMPLER_MIPMAP_MODE_LINEAR",
-        "addressModeU": "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-        "addressModeV": "VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT",
-        "addressModeW": "VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE",
-        "mipLodBias": 0.5,
-        "anisotropyEnable": "VK_FALSE",
-        "maxAnisotropy": 2.0,
-        "compareEnable": "VK_FALSE",
-        "compareOp": 137,
-        "minLod": "NaN",
-        "maxLod": 1000.0,
-        "borderColor": "VK_BORDER_COLOR_FLOAT_CUSTOM_EXT",
-        "unnormalizedCoordinates": "VK_TRUE"
-    })"};
+    {
+        auto [ci, ref_json] = getVkSamplerCreateInfo();
 
-    VkSamplerCreateInfo sampler_ci{};
-    VkSamplerReductionModeCreateInfo srm_ci{};
+        const char* result_json = nullptr;
 
-    sampler_ci.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+        EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, ci.ptr(), &result_json, &msg_));
+        CHECK_GEN(true);
+        EXPECT_TRUE(CompareJson(result_json, ref_json));
+    }
+    {
+        auto [ci, ref_json] =
+            getVkSamplerCreateInfo(1, std::make_tuple(getVkSamplerYcbcrConversionInfo(VkSamplerYcbcrConversion(12345)),
+                                                      getVkSamplerReductionModeCreateInfo(1)));
 
-    srm_ci.sType = VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO;
-    srm_ci.pNext = nullptr;
-    srm_ci.reductionMode = VK_SAMPLER_REDUCTION_MODE_MAX;
+        const char* result_json = nullptr;
 
-    sampler_ci.pNext = &srm_ci;
-    sampler_ci.flags = 0;
-    sampler_ci.magFilter = VK_FILTER_CUBIC_EXT;
-    sampler_ci.minFilter = VK_FILTER_NEAREST;
-    sampler_ci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-    sampler_ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-    sampler_ci.addressModeV = VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
-    sampler_ci.addressModeW = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
-    sampler_ci.mipLodBias = 0.5f;
-    sampler_ci.anisotropyEnable = VK_FALSE;
-    sampler_ci.maxAnisotropy = 2.0f;
-    sampler_ci.compareEnable = VK_FALSE;
-    sampler_ci.compareOp = static_cast<VkCompareOp>(137);
-    sampler_ci.minLod = std::numeric_limits<float>::quiet_NaN();
-    sampler_ci.maxLod = VK_LOD_CLAMP_NONE;  // NOTE: float constants can't be serialized as strings
-    sampler_ci.borderColor = VK_BORDER_COLOR_FLOAT_CUSTOM_EXT;
-    sampler_ci.unnormalizedCoordinates = VK_TRUE;
-
-    const char* result_json = nullptr;
-
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &sampler_ci, &result_json, &msg_));
-    CHECK_GEN(true);
-    EXPECT_TRUE(CompareJson(result_json, ref_json));
+        EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, ci.ptr(), &result_json, &msg_));
+        CHECK_GEN(true);
+        EXPECT_TRUE(CompareJson(result_json, ref_json));
+    }
 }
 
 TEST_F(Gen, VkDescriptorSetLayoutCreateInfo) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex descriptor set layout create info JSON");
 
-    std::string ref_json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO",
-        "pNext": {
-            "sType" : "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO",
-            "pNext": "NULL",
-            "bindingCount": 1,
-            "pBindingFlags": [
-                "VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT"
-            ]
-        },
-        "flags": "VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT",
-        "bindingCount": 1,
-        "pBindings": [
-            {
-                "binding": 12345,
-                "descriptorType": "VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER",
-                "descriptorCount": 1,
-                "stageFlags": "VK_SHADER_STAGE_ALL",
-                "pImmutableSamplers": "NULL"
-            }
-        ]
-    })"};
-
-    VkDescriptorSetLayoutCreateInfo dsl_ci{};
-    dsl_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-
-    VkDescriptorSetLayoutBindingFlagsCreateInfo dslbf_ci{};
-    dslbf_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO;
-    dslbf_ci.pNext = nullptr;
-    dslbf_ci.bindingCount = 1;
-    dsl_ci.pNext = &dslbf_ci;
-
-    VkDescriptorBindingFlags bindingFlags[1] = {};
-    bindingFlags[0] = VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT;
-    dslbf_ci.pBindingFlags = bindingFlags;
-
-    dsl_ci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT;
-    dsl_ci.bindingCount = 1;
-
-    VkDescriptorSetLayoutBinding bindings[1] = {};
-    bindings[0].binding = 12345;
-    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
-    bindings[0].descriptorCount = 1;
-    bindings[0].stageFlags = VK_SHADER_STAGE_ALL;
-    bindings[0].pImmutableSamplers = nullptr;
-
-    dsl_ci.pBindings = bindings;
+    auto [ci, ref_json] = getVkDescriptorSetLayoutCreateInfo(0,
+                                                             {{1, VK_SHADER_STAGE_VERTEX_BIT},
+                                                              {1, VK_SHADER_STAGE_FRAGMENT_BIT, VkSampler(1)},
+                                                              {1, VK_SHADER_STAGE_FRAGMENT_BIT, VkSampler(2)}},
+                                                             std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
 
     const char* result_json = nullptr;
 
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &dsl_ci, &result_json, &msg_));
+    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci, &result_json, &msg_));
     CHECK_GEN();
     EXPECT_TRUE(CompareJson(result_json, ref_json));
 }
@@ -923,44 +155,11 @@ TEST_F(Gen, VkDescriptorSetLayoutCreateInfo) {
 TEST_F(Gen, VkPipelineLayoutCreateInfo) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex pipeline layout create info JSON");
 
-    std::string ref_json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO",
-        "pNext": "NULL",
-        "flags": 0,
-        "setLayoutCount": 1,
-        "pSetLayouts": [
-            54321
-        ],
-        "pushConstantRangeCount": 1,
-        "pPushConstantRanges": [
-            {
-                "stageFlags": "VK_SHADER_STAGE_GEOMETRY_BIT | VK_SHADER_STAGE_COMPUTE_BIT",
-                "offset": 0,
-                "size": 8
-            }
-        ]
-    })"};
-
-    VkPipelineLayoutCreateInfo pl_ci{};
-    pl_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-    pl_ci.pNext = nullptr;
-    pl_ci.flags = 0;
-
-    VkDescriptorSetLayout setLayouts[1] = {};
-    pl_ci.setLayoutCount = 1;
-    setLayouts[0] = VkDescriptorSetLayout(54321);
-    pl_ci.pSetLayouts = setLayouts;
-
-    VkPushConstantRange pushConstantRanges[1] = {};
-    pl_ci.pushConstantRangeCount = 1;
-    pushConstantRanges[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT | VK_SHADER_STAGE_GEOMETRY_BIT;
-    pushConstantRanges[0].offset = 0;
-    pushConstantRanges[0].size = 8;
-    pl_ci.pPushConstantRanges = pushConstantRanges;
+    auto [ci, ref_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(12345)}});
 
     const char* result_json = nullptr;
 
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &pl_ci, &result_json, &msg_));
+    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci, &result_json, &msg_));
     CHECK_GEN();
     EXPECT_TRUE(CompareJson(result_json, ref_json));
 }
@@ -968,213 +167,12 @@ TEST_F(Gen, VkPipelineLayoutCreateInfo) {
 TEST_F(Gen, VkRenderPassCreateInfo) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex render pass create info JSON");
 
-    std::string ref_json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO",
-        "pNext": {
-            "sType" : "VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO",
-            "pNext": {
-                "sType" : "VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO",
-                "pNext": "NULL",
-                "subpassCount": 1,
-                "pViewMasks": [ 1 ],
-                "dependencyCount": 2,
-                "pViewOffsets": [ 0, 1 ],
-                "correlationMaskCount": 1,
-                "pCorrelationMasks": [ 8 ]
-            },
-            "aspectReferenceCount": 1,
-            "pAspectReferences": [
-                {
-                    "subpass": 1,
-                    "inputAttachmentIndex": 2,
-                    "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
-                }
-            ]
-        },
-        "flags": 0,
-        "attachmentCount": 1,
-        "pAttachments": [
-            {
-                "flags": "VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT",
-                "format": "VK_FORMAT_R8G8_USCALED",
-                "samples": "VK_SAMPLE_COUNT_8_BIT",
-                "loadOp": "VK_ATTACHMENT_LOAD_OP_DONT_CARE",
-                "storeOp": "VK_ATTACHMENT_STORE_OP_STORE",
-                "stencilLoadOp": "VK_ATTACHMENT_LOAD_OP_LOAD",
-                "stencilStoreOp": "VK_ATTACHMENT_STORE_OP_DONT_CARE",
-                "initialLayout": "VK_IMAGE_LAYOUT_GENERAL",
-                "finalLayout": "VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR"
-            }
-        ],
-        "subpassCount": 2,
-        "pSubpasses": [
-            {
-                "flags": 0,
-                "pipelineBindPoint": "VK_PIPELINE_BIND_POINT_GRAPHICS",
-                "inputAttachmentCount": 1,
-                "pInputAttachments": [
-                    {
-                        "attachment": 567,
-                        "layout": "VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL"
-                    }
-                ],
-                "colorAttachmentCount": 1,
-                "pColorAttachments": [
-                    {
-                        "attachment": 4294967295,
-                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED"
-                    }
-                ],
-                "pResolveAttachments": [
-                    {
-                        "attachment": 4294967295,
-                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED"
-                    }
-                ],
-                "pDepthStencilAttachment": {
-                    "attachment": 4294967295,
-                    "layout": "VK_IMAGE_LAYOUT_UNDEFINED"
-                },
-                "preserveAttachmentCount": 0,
-                "pPreserveAttachments": "NULL"
-            },
-            {
-                "flags": 0,
-                "pipelineBindPoint": "VK_PIPELINE_BIND_POINT_GRAPHICS",
-                "inputAttachmentCount": 0,
-                "pInputAttachments": "NULL",
-                "colorAttachmentCount": 1,
-                "pColorAttachments": [
-                    {
-                        "attachment": 567,
-                        "layout": "VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL"
-                    }
-                ],
-                "pResolveAttachments": [
-                    {
-                        "attachment": 4294967295,
-                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED"
-                    }
-                ],
-                "pDepthStencilAttachment": {
-                    "attachment": 4294967295,
-                    "layout": "VK_IMAGE_LAYOUT_UNDEFINED"
-                },
-                "preserveAttachmentCount": 0,
-                "pPreserveAttachments": "NULL"
-            }
-        ],
-        "dependencyCount": 1,
-        "pDependencies": [
-            {
-                "srcSubpass": 4294967295,
-                "dstSubpass": 2345,
-                "srcStageMask": 0,
-                "dstStageMask": "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "srcAccessMask": 0,
-                "dstAccessMask": "VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT",
-                "dependencyFlags": "VK_DEPENDENCY_DEVICE_GROUP_BIT"
-            }
-        ]
-    })"};
-
-    VkRenderPassCreateInfo rp_ci{};
-    VkRenderPassInputAttachmentAspectCreateInfo rpiaa_ci{};
-    VkRenderPassMultiviewCreateInfo rpmv_ci{};
-
-    rp_ci.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-
-    rpiaa_ci.sType = VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO;
-    rpiaa_ci.aspectReferenceCount = 1;
-
-    VkInputAttachmentAspectReference aspectReferences[1] = {};
-    aspectReferences[0].subpass = 1;
-    aspectReferences[0].inputAttachmentIndex = 2;
-    aspectReferences[0].aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    rpiaa_ci.pAspectReferences = aspectReferences;
-
-    rpmv_ci.sType = VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO;
-    rpmv_ci.pNext = nullptr;
-    rpmv_ci.subpassCount = 1;
-
-    uint32_t viewMasks[1] = {1};
-    rpmv_ci.pViewMasks = viewMasks;
-
-    int32_t viewOffsets[2] = {0, 1};
-    rpmv_ci.dependencyCount = 2;
-    rpmv_ci.pViewOffsets = viewOffsets;
-
-    uint32_t correlationMasks[1] = {8};
-    rpmv_ci.correlationMaskCount = 1;
-    rpmv_ci.pCorrelationMasks = correlationMasks;
-
-    rpiaa_ci.pNext = &rpmv_ci;
-    rp_ci.pNext = &rpiaa_ci;
-
-    rp_ci.flags = 0;
-
-    VkAttachmentDescription attachments[1] = {};
-    rp_ci.attachmentCount = 1;
-    attachments[0].flags = VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT;
-    attachments[0].format = VK_FORMAT_R8G8_USCALED;
-    attachments[0].samples = VK_SAMPLE_COUNT_8_BIT;
-    attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-    attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
-    attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    attachments[0].initialLayout = VK_IMAGE_LAYOUT_GENERAL;
-    attachments[0].finalLayout = VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR;
-    rp_ci.pAttachments = attachments;
-
-    VkSubpassDescription subpasses[2] = {};
-    rp_ci.subpassCount = 2;
-    subpasses[0].flags = 0;
-    subpasses[0].pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-
-    VkAttachmentReference subpass_0_inputAttachments[1] = {{567, VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL}};
-    subpasses[0].inputAttachmentCount = 1;
-    subpasses[0].pInputAttachments = subpass_0_inputAttachments;
-
-    VkAttachmentReference subpass_0_colorAttachments[1] = {{VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_UNDEFINED}};
-    VkAttachmentReference subpass_0_resolveAttachments[1] = {{VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_UNDEFINED}};
-    VkAttachmentReference subpass_0_deptStencilAttachments[1] = {{VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_UNDEFINED}};
-    subpasses[0].colorAttachmentCount = 1;
-    subpasses[0].pColorAttachments = subpass_0_colorAttachments;
-    subpasses[0].pResolveAttachments = subpass_0_resolveAttachments;
-    subpasses[0].pDepthStencilAttachment = subpass_0_deptStencilAttachments;
-    subpasses[0].preserveAttachmentCount = 0;
-    subpasses[0].pPreserveAttachments = nullptr;
-
-    subpasses[1].flags = 0;
-    subpasses[1].pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-    subpasses[1].inputAttachmentCount = 0;
-    subpasses[1].pInputAttachments = nullptr;
-
-    VkAttachmentReference subpass_1_colorAttachments[1] = {{567, VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL_KHR}};
-    VkAttachmentReference subpass_1_resolveAttachments[1] = {{VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_UNDEFINED}};
-    VkAttachmentReference subpass_1_deptStencilAttachments[1] = {{VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_UNDEFINED}};
-    subpasses[1].colorAttachmentCount = 1;
-    subpasses[1].pColorAttachments = subpass_1_colorAttachments;
-    subpasses[1].pResolveAttachments = subpass_1_resolveAttachments;
-    subpasses[1].pDepthStencilAttachment = subpass_1_deptStencilAttachments;
-    subpasses[1].preserveAttachmentCount = 0;
-    subpasses[1].pPreserveAttachments = nullptr;
-    rp_ci.pSubpasses = subpasses;
-
-    VkSubpassDependency dependencies[1] = {};
-    rp_ci.dependencyCount = 1;
-    dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
-    dependencies[0].dstSubpass = 2345;
-    dependencies[0].srcStageMask = VK_PIPELINE_STAGE_NONE_KHR;
-    dependencies[0].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dependencies[0].srcAccessMask = VK_ACCESS_NONE_KHR;
-    dependencies[0].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-    dependencies[0].dependencyFlags = VK_DEPENDENCY_DEVICE_GROUP_BIT;
-    rp_ci.pDependencies = dependencies;
+    auto [ci, ref_json] = getVkRenderPassCreateInfo(
+        0, std::make_tuple(getVkRenderPassInputAttachmentAspectCreateInfo(), getVkRenderPassMultiviewCreateInfo()));
 
     const char* result_json = nullptr;
 
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &rp_ci, &result_json, &msg_));
+    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci, &result_json, &msg_));
     CHECK_GEN();
     EXPECT_TRUE(CompareJson(result_json, ref_json));
 }
@@ -1182,306 +180,11 @@ TEST_F(Gen, VkRenderPassCreateInfo) {
 TEST_F(Gen, VkRenderPassCreateInfo2) {
     TEST_DESCRIPTION("Tests generating of a reasonably complex render pass 2 layout create info JSON");
 
-    std::string ref_json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2",
-        "pNext": "NULL",
-        "flags": 0,
-        "attachmentCount": 1,
-        "pAttachments": [
-            {
-                "sType" : "VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2",
-                "pNext": {
-                    "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT",
-                    "pNext": "NULL",
-                    "stencilInitialLayout": "VK_IMAGE_LAYOUT_GENERAL",
-                    "stencilFinalLayout": "VK_IMAGE_LAYOUT_GENERAL"
-                },
-                "flags": "VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT",
-                "format": "VK_FORMAT_R8G8_USCALED",
-                "samples": "VK_SAMPLE_COUNT_8_BIT",
-                "loadOp": "VK_ATTACHMENT_LOAD_OP_DONT_CARE",
-                "storeOp": "VK_ATTACHMENT_STORE_OP_STORE",
-                "stencilLoadOp": "VK_ATTACHMENT_LOAD_OP_LOAD",
-                "stencilStoreOp": "VK_ATTACHMENT_STORE_OP_DONT_CARE",
-                "initialLayout": "VK_IMAGE_LAYOUT_GENERAL",
-                "finalLayout": "VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR"
-            }
-        ],
-        "subpassCount": 2,
-        "pSubpasses": [
-            {
-                "sType" : "VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2",
-                "pNext": {
-                    "sType" : "VK_STRUCTURE_TYPE_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR",
-                    "pNext": {
-                        "sType" : "VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE",
-                        "pNext": "NULL",
-                        "depthResolveMode": "VK_RESOLVE_MODE_MIN_BIT",
-                        "stencilResolveMode": "VK_RESOLVE_MODE_MAX_BIT",
-                        "pDepthStencilResolveAttachment": {
-                            "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
-                            "pNext": "NULL",
-                            "attachment": 8,
-                            "layout": "VK_IMAGE_LAYOUT_GENERAL",
-                            "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
-                        }
-                    },
-                    "pFragmentShadingRateAttachment": {
-                        "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
-                        "pNext": "NULL",
-                        "attachment": 5,
-                        "layout": "VK_IMAGE_LAYOUT_GENERAL",
-                        "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
-                    },
-                    "shadingRateAttachmentTexelSize": {
-                        "width": 4,
-                        "height": 4
-                    }
-                },
-                "flags": 0,
-                "pipelineBindPoint": "VK_PIPELINE_BIND_POINT_GRAPHICS",
-                "viewMask": 0,
-                "inputAttachmentCount": 1,
-                "pInputAttachments": [
-                    {
-                        "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
-                        "pNext": "NULL",
-                        "attachment": 567,
-                        "layout": "VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL",
-                        "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
-                    }
-                ],
-                "colorAttachmentCount": 1,
-                "pColorAttachments": [
-                    {
-                        "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
-                        "pNext": "NULL",
-                        "attachment": 4294967295,
-                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED",
-                        "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
-                    }
-                ],
-                "pResolveAttachments": [
-                    {
-                        "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
-                        "pNext": "NULL",
-                        "attachment": 4294967295,
-                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED",
-                        "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
-                    }
-                ],
-                "pDepthStencilAttachment": {
-                    "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
-                    "pNext": "NULL",
-                    "attachment": 4294967295,
-                    "layout": "VK_IMAGE_LAYOUT_UNDEFINED",
-                    "aspectMask": "VK_IMAGE_ASPECT_DEPTH_BIT"
-                },
-                "preserveAttachmentCount": 0,
-                "pPreserveAttachments": "NULL"
-            },
-            {
-                "sType" : "VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2",
-                "pNext": "NULL",
-                "flags": 0,
-                "pipelineBindPoint": "VK_PIPELINE_BIND_POINT_GRAPHICS",
-                "viewMask": 0,
-                "inputAttachmentCount": 0,
-                "pInputAttachments": "NULL",
-                "colorAttachmentCount": 1,
-                "pColorAttachments": [
-                    {
-                        "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
-                        "pNext": "NULL",
-                        "attachment": 567,
-                        "layout": "VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL",
-                        "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
-                    }
-                ],
-                "pResolveAttachments": [
-                    {
-                        "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
-                        "pNext": "NULL",
-                        "attachment": 4294967295,
-                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED",
-                        "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
-                    }
-                ],
-                "pDepthStencilAttachment": {
-                    "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
-                    "pNext": "NULL",
-                    "attachment": 4294967295,
-                    "layout": "VK_IMAGE_LAYOUT_UNDEFINED",
-                    "aspectMask": "VK_IMAGE_ASPECT_DEPTH_BIT"
-                },
-                "preserveAttachmentCount": 0,
-                "pPreserveAttachments": "NULL"
-            }
-        ],
-        "dependencyCount": 1,
-        "pDependencies": [
-            {
-                "sType" : "VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2",
-                "pNext": {
-                    "sType" : "VK_STRUCTURE_TYPE_MEMORY_BARRIER_2",
-                    "pNext": "NULL",
-                    "srcStageMask": "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
-                    "srcAccessMask": "VK_ACCESS_2_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT",
-                    "dstStageMask": "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
-                    "dstAccessMask": "VK_ACCESS_2_COMMAND_PREPROCESS_READ_BIT_EXT"
-                },
-                "srcSubpass": 4294967295,
-                "dstSubpass": 2345,
-                "srcStageMask": 0,
-                "dstStageMask": "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "srcAccessMask": 0,
-                "dstAccessMask": "VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT",
-                "dependencyFlags": "VK_DEPENDENCY_DEVICE_GROUP_BIT",
-                "viewOffset": 0
-            }
-        ],
-        "correlatedViewMaskCount": 1,
-        "pCorrelatedViewMasks": [ 8 ]
-    })"};
-
-    VkRenderPassCreateInfo2 rp2_ci{};
-
-    VkAttachmentDescriptionStencilLayout adsl{};
-    VkFragmentShadingRateAttachmentInfoKHR fsrai{};
-
-    VkMemoryBarrier2KHR mb2{};
-
-    rp2_ci.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2;
-    rp2_ci.pNext = nullptr;
-    rp2_ci.flags = 0;
-
-    adsl.sType = VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT;
-    adsl.pNext = nullptr;
-    adsl.stencilInitialLayout = VK_IMAGE_LAYOUT_GENERAL;
-    adsl.stencilFinalLayout = VK_IMAGE_LAYOUT_GENERAL;
-
-    VkAttachmentDescription2 attachments[1] = {};
-    rp2_ci.attachmentCount = 1;
-    attachments[0].sType = VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2;
-    attachments[0].flags = VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT;
-    attachments[0].format = VK_FORMAT_R8G8_USCALED;
-    attachments[0].samples = VK_SAMPLE_COUNT_8_BIT;
-    attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-    attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
-    attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    attachments[0].initialLayout = VK_IMAGE_LAYOUT_GENERAL;
-    attachments[0].finalLayout = VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR;
-    attachments[0].pNext = &adsl;
-    rp2_ci.pAttachments = attachments;
-
-    VkAttachmentReference2 depthStencilResolveAttachment{};
-    depthStencilResolveAttachment.sType = VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2;
-    depthStencilResolveAttachment.pNext = nullptr;
-    depthStencilResolveAttachment.attachment = 8;
-    depthStencilResolveAttachment.layout = VK_IMAGE_LAYOUT_GENERAL;
-    depthStencilResolveAttachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-
-    VkSubpassDescriptionDepthStencilResolve sddsr{};
-    sddsr.sType = VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE;
-    sddsr.pNext = nullptr;
-    sddsr.depthResolveMode = VK_RESOLVE_MODE_MIN_BIT;
-    sddsr.stencilResolveMode = VK_RESOLVE_MODE_MAX_BIT;
-    sddsr.pDepthStencilResolveAttachment = &depthStencilResolveAttachment;
-
-    VkAttachmentReference2 fragmentShadingRateAttachment{};
-    fsrai.sType = VK_STRUCTURE_TYPE_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR;
-    fragmentShadingRateAttachment.sType = VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2;
-    fragmentShadingRateAttachment.pNext = nullptr;
-    fragmentShadingRateAttachment.attachment = 5;
-    fragmentShadingRateAttachment.layout = VK_IMAGE_LAYOUT_GENERAL;
-    fragmentShadingRateAttachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    fsrai.pFragmentShadingRateAttachment = &fragmentShadingRateAttachment;
-    fsrai.pNext = &sddsr;
-
-    fsrai.shadingRateAttachmentTexelSize.width = 4;
-    fsrai.shadingRateAttachmentTexelSize.height = 4;
-
-    VkSubpassDescription2 subpasses[2] = {};
-    rp2_ci.subpassCount = 2;
-
-    subpasses[0].sType = VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2;
-    subpasses[0].flags = 0;
-    subpasses[0].pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-    subpasses[0].inputAttachmentCount = 1;
-
-    VkAttachmentReference2 subpass_0_inputAttachments[1] = {
-        {VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, nullptr, 567, VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL, VK_IMAGE_ASPECT_COLOR_BIT}};
-    subpasses[0].pInputAttachments = subpass_0_inputAttachments;
-
-    subpasses[0].colorAttachmentCount = 1;
-    VkAttachmentReference2 subpass_0_colorAttachments[1] = {{VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, nullptr,
-                                                             VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_UNDEFINED,
-                                                             VK_IMAGE_ASPECT_COLOR_BIT}};
-    VkAttachmentReference2 subpass_0_resolveAttachments[1] = {{VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, nullptr,
-                                                               VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_UNDEFINED,
-                                                               VK_IMAGE_ASPECT_COLOR_BIT}};
-    VkAttachmentReference2 subpass_0_depthStencilAttachments[1] = {{VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, nullptr,
-                                                                    VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_UNDEFINED,
-                                                                    VK_IMAGE_ASPECT_DEPTH_BIT}};
-    subpasses[0].pColorAttachments = subpass_0_colorAttachments;
-    subpasses[0].pResolveAttachments = subpass_0_resolveAttachments;
-    subpasses[0].pDepthStencilAttachment = subpass_0_depthStencilAttachments;
-    subpasses[0].preserveAttachmentCount = 0;
-    subpasses[0].pPreserveAttachments = nullptr;
-    subpasses[0].pNext = &fsrai;
-
-    subpasses[1].sType = VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2;
-    subpasses[1].pNext = nullptr;
-    subpasses[1].flags = 0;
-    subpasses[1].pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-    subpasses[1].inputAttachmentCount = 0;
-    subpasses[1].pInputAttachments = nullptr;
-
-    subpasses[1].colorAttachmentCount = 1;
-    VkAttachmentReference2 subpass_1_colorAttachments[1] = {
-        {VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, nullptr, 567, VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL_KHR, VK_IMAGE_ASPECT_COLOR_BIT}};
-    VkAttachmentReference2 subpass_1_resolveAttachments[1] = {{VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, nullptr,
-                                                               VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_UNDEFINED,
-                                                               VK_IMAGE_ASPECT_COLOR_BIT}};
-    VkAttachmentReference2 subpass_1_depthStencilAttachments[1] = {{VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, nullptr,
-                                                                    VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_UNDEFINED,
-                                                                    VK_IMAGE_ASPECT_DEPTH_BIT}};
-    subpasses[1].pColorAttachments = subpass_1_colorAttachments;
-    subpasses[1].pResolveAttachments = subpass_1_resolveAttachments;
-    subpasses[1].pDepthStencilAttachment = subpass_1_depthStencilAttachments;
-    subpasses[1].preserveAttachmentCount = 0;
-    subpasses[1].pPreserveAttachments = nullptr;
-
-    rp2_ci.pSubpasses = subpasses;
-
-    mb2.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2_KHR;
-    mb2.pNext = nullptr;
-    mb2.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
-    mb2.srcAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT;
-    mb2.dstStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
-    mb2.dstAccessMask = VK_ACCESS_2_COMMAND_PREPROCESS_READ_BIT_NV;
-
-    rp2_ci.dependencyCount = 1;
-    VkSubpassDependency2 dependencies[1] = {};
-    dependencies[0].sType = VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2;
-    dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
-    dependencies[0].dstSubpass = 2345;
-    dependencies[0].srcStageMask = VK_PIPELINE_STAGE_NONE_KHR;
-    dependencies[0].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dependencies[0].srcAccessMask = VK_ACCESS_NONE_KHR;
-    dependencies[0].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-    dependencies[0].dependencyFlags = VK_DEPENDENCY_DEVICE_GROUP_BIT;
-    dependencies[0].pNext = &mb2;
-    rp2_ci.pDependencies = dependencies;
-
-    rp2_ci.correlatedViewMaskCount = 1;
-    uint32_t correlatedViewMasks[1] = {8};
-    rp2_ci.pCorrelatedViewMasks = correlatedViewMasks;
+    auto [ci, ref_json] = getVkRenderPassCreateInfo2(0);
 
     const char* result_json = nullptr;
 
-    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &rp2_ci, &result_json, &msg_));
+    EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &ci, &result_json, &msg_));
     CHECK_GEN();
     EXPECT_TRUE(CompareJson(result_json, ref_json));
 }
@@ -1709,440 +412,42 @@ TEST_F(Gen, VkPipelineOfflineCreateInfo) {
 TEST_F(Gen, ComputePipelineJSON) {
     TEST_DESCRIPTION("Tests generation of a reasonably complex compute pipeline JSON");
 
-    const std::string ref_json{R"({
-    "ComputePipelineState" : 
-    {
-        "ComputePipeline" : 
-        {
-            "basePipelineHandle" : "",
-            "basePipelineIndex" : 0,
-            "flags" : 0,
-            "layout" : "",
-            "pNext" : "NULL",
-            "sType" : "VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO",
-            "stage" : 
-            {
-                "flags" : "VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT",
-                "module" : "",
-                "pName" : "main",
-                "pNext" : 
-                {
-                    "pNext" : "NULL",
-                    "requiredSubgroupSize" : 64,
-                    "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO"
-                },
-                "pSpecializationInfo" : "NULL",
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                "stage" : "VK_SHADER_STAGE_COMPUTE_BIT"
-            }
-        },
-)"
-                               R"(
-        "DescriptorSetLayouts" : 
-        [
-            {
-                "DescriptorSetLayout1" : 
-                {
-                    "bindingCount" : 3,
-                    "flags" : "VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT",
-                    "pBindings" : 
-                    [
-                        {
-                            "binding" : 0,
-                            "descriptorCount" : 1,
-                            "descriptorType" : "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
-                            "pImmutableSamplers" : [],
-                            "stageFlags" : "VK_SHADER_STAGE_COMPUTE_BIT"
-                        },
-                        {
-                            "binding" : 1,
-                            "descriptorCount" : 1,
-                            "descriptorType" : "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
-                            "pImmutableSamplers" : 
-                            [
-                                "ImmutableSampler1"
-                            ],
-                            "stageFlags" : "VK_SHADER_STAGE_COMPUTE_BIT"
-                        },
-                        {
-                            "binding" : 2,
-                            "descriptorCount" : 1,
-                            "descriptorType" : "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
-                            "pImmutableSamplers" : 
-                            [
-                                "YcbcrSampler1"
-                            ],
-                            "stageFlags" : "VK_SHADER_STAGE_COMPUTE_BIT"
-                        }
-                    ],
-                    "pNext" : 
-                    {
-                        "bindingCount" : 1,
-                        "pBindingFlags" : 
-                        [
-                            "VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT"
-                        ],
-                        "pNext" : "NULL",
-                        "sType" : "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO"
-                    },
-                    "sType" : "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO"
-                }
-            }
-        ],
-)"
-                               R"(
-        "ImmutableSamplers" : 
-        [
-            {
-                "ImmutableSampler1" : 
-                {
-                    "addressModeU" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "addressModeV" : "VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT",
-                    "addressModeW" : "VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE",
-                    "anisotropyEnable" : "VK_FALSE",
-                    "borderColor" : "VK_BORDER_COLOR_FLOAT_CUSTOM_EXT",
-                    "compareEnable" : "VK_FALSE",
-                    "compareOp" : "VK_COMPARE_OP_NEVER",
-                    "flags" : 0,
-                    "magFilter" : "VK_FILTER_CUBIC_EXT",
-                    "maxAnisotropy" : 2.0,
-                    "maxLod" : 1000.0,
-                    "minFilter" : "VK_FILTER_NEAREST",
-                    "minLod" : 0.5,
-                    "mipLodBias" : 0.5,
-                    "mipmapMode" : "VK_SAMPLER_MIPMAP_MODE_LINEAR",
-                    "pNext" : 
-                    {
-                        "pNext" : "NULL",
-                        "reductionMode" : "VK_SAMPLER_REDUCTION_MODE_MAX",
-                        "sType" : "VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO"
-                    },
-                    "sType" : "VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO",
-                    "unnormalizedCoordinates" : "VK_TRUE"
-                }
-            },
-            {
-                "YcbcrSampler1" : 
-                {
-                    "addressModeU" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "addressModeV" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "addressModeW" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "anisotropyEnable" : "VK_FALSE",
-                    "borderColor" : "VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK",
-                    "compareEnable" : "VK_FALSE",
-                    "compareOp" : "VK_COMPARE_OP_NEVER",
-                    "flags" : 0,
-                    "magFilter" : "VK_FILTER_NEAREST",
-                    "maxAnisotropy" : 0.0,
-                    "maxLod" : 0.0,
-                    "minFilter" : "VK_FILTER_NEAREST",
-                    "minLod" : 0.0,
-                    "mipLodBias" : 0.0,
-                    "mipmapMode" : "VK_SAMPLER_MIPMAP_MODE_NEAREST",
-                    "pNext" : 
-                    {
-                        "conversion" : "YcbcrConversion1",
-                        "pNext" : "NULL",
-                        "sType" : "VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO"
-                    },
-                    "sType" : "VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO",
-                    "unnormalizedCoordinates" : "VK_FALSE"
-                }
-            }
-        ],
-)"
-                               R"(
-        "PhysicalDeviceFeatures" : 
-        {
-            "features" : 
-            {
-                "alphaToOne" : "VK_FALSE",
-                "depthBiasClamp" : "VK_FALSE",
-                "depthBounds" : "VK_FALSE",
-                "depthClamp" : "VK_FALSE",
-                "drawIndirectFirstInstance" : "VK_FALSE",
-                "dualSrcBlend" : "VK_FALSE",
-                "fillModeNonSolid" : "VK_FALSE",
-                "fragmentStoresAndAtomics" : "VK_FALSE",
-                "fullDrawIndexUint32" : "VK_FALSE",
-                "geometryShader" : "VK_FALSE",
-                "imageCubeArray" : "VK_FALSE",
-                "independentBlend" : "VK_FALSE",
-                "inheritedQueries" : "VK_FALSE",
-                "largePoints" : "VK_FALSE",
-                "logicOp" : "VK_FALSE",
-                "multiDrawIndirect" : "VK_FALSE",
-                "multiViewport" : "VK_FALSE",
-                "occlusionQueryPrecise" : "VK_FALSE",
-                "pipelineStatisticsQuery" : "VK_FALSE",
-                "robustBufferAccess" : "VK_TRUE",
-                "sampleRateShading" : "VK_FALSE",
-                "samplerAnisotropy" : "VK_FALSE",
-                "shaderClipDistance" : "VK_FALSE",
-                "shaderCullDistance" : "VK_FALSE",
-                "shaderFloat64" : "VK_FALSE",
-                "shaderImageGatherExtended" : "VK_FALSE",
-                "shaderInt16" : "VK_FALSE",
-                "shaderInt64" : "VK_FALSE",
-                "shaderResourceMinLod" : "VK_FALSE",
-                "shaderResourceResidency" : "VK_FALSE",
-                "shaderSampledImageArrayDynamicIndexing" : "VK_FALSE",
-                "shaderStorageBufferArrayDynamicIndexing" : "VK_FALSE",
-                "shaderStorageImageArrayDynamicIndexing" : "VK_FALSE",
-                "shaderStorageImageExtendedFormats" : "VK_FALSE",
-                "shaderStorageImageMultisample" : "VK_FALSE",
-                "shaderStorageImageReadWithoutFormat" : "VK_FALSE",
-                "shaderStorageImageWriteWithoutFormat" : "VK_FALSE",
-                "shaderTessellationAndGeometryPointSize" : "VK_FALSE",
-                "shaderUniformBufferArrayDynamicIndexing" : "VK_FALSE",
-                "sparseBinding" : "VK_FALSE",
-                "sparseResidency16Samples" : "VK_FALSE",
-                "sparseResidency2Samples" : "VK_FALSE",
-                "sparseResidency4Samples" : "VK_FALSE",
-                "sparseResidency8Samples" : "VK_FALSE",
-                "sparseResidencyAliased" : "VK_FALSE",
-                "sparseResidencyBuffer" : "VK_FALSE",
-                "sparseResidencyImage2D" : "VK_FALSE",
-                "sparseResidencyImage3D" : "VK_FALSE",
-                "tessellationShader" : "VK_FALSE",
-                "textureCompressionASTC_LDR" : "VK_FALSE",
-                "textureCompressionBC" : "VK_FALSE",
-                "textureCompressionETC2" : "VK_FALSE",
-                "variableMultisampleRate" : "VK_FALSE",
-                "vertexPipelineStoresAndAtomics" : "VK_FALSE",
-                "wideLines" : "VK_FALSE"
-            },
-            "pNext" : 
-            {
-                "pNext" : "NULL",
-                "sType" : "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES",
-                "synchronization2" : "VK_TRUE"
-            },
-            "sType" : "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2"
-        },
-)"
-                               R"(
-        "PipelineLayout" : 
-        {
-            "flags" : 0,
-            "pNext" : "NULL",
-            "pPushConstantRanges" : 
-            [
-                {
-                    "offset" : 0,
-                    "size" : 4,
-                    "stageFlags" : "VK_SHADER_STAGE_COMPUTE_BIT"
-                }
-            ],
-            "pSetLayouts" : 
-            [
-                "DescriptorSetLayout1"
-            ],
-            "pushConstantRangeCount" : 1,
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO",
-            "setLayoutCount" : 1
-        },
-        "ShaderFileNames" : 
-        [
-            {
-                "filename" : "shader.comp.spv",
-                "stage" : "VK_SHADER_STAGE_COMPUTE_BIT"
-            }
-        ],
-        "YcbcrSamplers" : 
-        [
-            {
-                "YcbcrConversion1" : 
-                {
-                    "chromaFilter" : "VK_FILTER_CUBIC_EXT",
-                    "components" : 
-                    {
-                        "a" : "VK_COMPONENT_SWIZZLE_R",
-                        "b" : "VK_COMPONENT_SWIZZLE_G",
-                        "g" : "VK_COMPONENT_SWIZZLE_B",
-                        "r" : "VK_COMPONENT_SWIZZLE_A"
-                    },
-                    "forceExplicitReconstruction" : "VK_TRUE",
-                    "format" : "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16",
-                    "pNext" : "NULL",
-                    "sType" : "VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO",
-                    "xChromaOffset" : "VK_CHROMA_LOCATION_COSITED_EVEN",
-                    "yChromaOffset" : "VK_CHROMA_LOCATION_MIDPOINT",
-                    "ycbcrModel" : "VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020",
-                    "ycbcrRange" : "VK_SAMPLER_YCBCR_RANGE_ITU_NARROW"
-                }
-            }
-        ]
-    },
-    "EnabledExtensions" : 
-    [
-        "VK_EXT_robustness2"
-    ],
-    "PipelineUUID" : 
-    [
-        85,
-        43,
-        255,
-        24,
-        155,
-        64,
-        62,
-        24,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0
-    ]
-})"};
-
     VpjData data{};
 
-    VkSamplerYcbcrConversionCreateInfo ycbcr_ci;
     const char* ycbcr_names[1] = {"YcbcrConversion1"};
-    ycbcr_ci.sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO;
-#ifdef VK_USE_PLATFORM_SCREEN_QNX
-    VkExternalFormatQNX ef_qnx{};
-    ef_qnx.sType = VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_QNX;
-    ef_qnx.pNext = nullptr;
-    ef_qnx.externalFormat = 10;
-    ycbcr_ci.pNext = &ef_qnx;
-#else
-    ycbcr_ci.pNext = nullptr;
-#endif  // VK_USE_PLATFORM_SCREEN_QNX
-    ycbcr_ci.format = VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16;
-    ycbcr_ci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020;
-    ycbcr_ci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_NARROW;
-    ycbcr_ci.components.r = VK_COMPONENT_SWIZZLE_A;
-    ycbcr_ci.components.g = VK_COMPONENT_SWIZZLE_B;
-    ycbcr_ci.components.b = VK_COMPONENT_SWIZZLE_G;
-    ycbcr_ci.components.a = VK_COMPONENT_SWIZZLE_R;
-    ycbcr_ci.xChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
-    ycbcr_ci.yChromaOffset = VK_CHROMA_LOCATION_MIDPOINT;
-    ycbcr_ci.chromaFilter = VK_FILTER_CUBIC_EXT;
-    ycbcr_ci.forceExplicitReconstruction = VK_TRUE;
+    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
+    auto ycbcr_conversion = VkSamplerYcbcrConversion(0);
 
-    VkSamplerCreateInfo sampler_ci[2] = {};
     const char* sampler_names[2] = {"ImmutableSampler1", "YcbcrSampler1"};
-
-    VkSamplerYcbcrConversionInfo ycbcrConversionInfo[1] = {};
-
-    ycbcrConversionInfo[0].sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO;
-    ycbcrConversionInfo[0].conversion = VkSamplerYcbcrConversion(0);
-
+    auto [immut_sampler_ci, immut_sampler_json] =
+        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerReductionModeCreateInfo(VK_SAMPLER_REDUCTION_MODE_MAX)));
+    auto [ycbcr_sampler_ci, ycbcr_sampler_json] =
+        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerYcbcrConversionInfo(ycbcr_conversion, ycbcr_names[0])));
+    VkSamplerCreateInfo sampler_ci[2] = {*immut_sampler_ci.ptr(), *ycbcr_sampler_ci.ptr()};
     VkSampler immutableSamplers[2] = {VkSampler(0), VkSampler(1)};
 
-    sampler_ci[0].sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    VkSamplerReductionModeCreateInfo srm_ci{};
-    srm_ci.sType = VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO;
-    srm_ci.pNext = nullptr;
-    srm_ci.reductionMode = VK_SAMPLER_REDUCTION_MODE_MAX;
-    sampler_ci[0].pNext = &srm_ci;
-    sampler_ci[0].flags = 0;
-    sampler_ci[0].magFilter = VK_FILTER_CUBIC_EXT;
-    sampler_ci[0].minFilter = VK_FILTER_NEAREST;
-    sampler_ci[0].mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-    sampler_ci[0].addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-    sampler_ci[0].addressModeV = VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
-    sampler_ci[0].addressModeW = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
-    sampler_ci[0].mipLodBias = 0.5f;
-    sampler_ci[0].anisotropyEnable = VK_FALSE;
-    sampler_ci[0].maxAnisotropy = 2.0f;
-    sampler_ci[0].compareEnable = VK_FALSE;
-    sampler_ci[0].compareOp = VK_COMPARE_OP_NEVER;
-    sampler_ci[0].minLod = 0.5f;
-    sampler_ci[0].maxLod = VK_LOD_CLAMP_NONE;
-    sampler_ci[0].borderColor = VK_BORDER_COLOR_FLOAT_CUSTOM_EXT;
-    sampler_ci[0].unnormalizedCoordinates = VK_TRUE;
-
-    sampler_ci[1].sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    sampler_ci[1].pNext = &ycbcrConversionInfo;
-
-    VkComputePipelineCreateInfo cp_ci{};
-    cp_ci.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
-    cp_ci.pNext = nullptr;
-    cp_ci.flags = 0;
-    cp_ci.stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-
-    VkPipelineLayoutCreateInfo pl_ci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
-
-    VkDescriptorSetLayout setLayouts[3] = {VkDescriptorSetLayout(0)};
-    pl_ci.setLayoutCount = 1;
-    pl_ci.pSetLayouts = setLayouts;
-    VkPushConstantRange pushConstantRanges[1] = {};
-    pl_ci.pushConstantRangeCount = 1;
-    pushConstantRanges[0].size = 4;
-    pushConstantRanges[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    pl_ci.pPushConstantRanges = pushConstantRanges;
-
-    VkPipelineShaderStageRequiredSubgroupSizeCreateInfo pssrss_ci{};
-    pssrss_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO;
-    pssrss_ci.pNext = nullptr;
-    pssrss_ci.requiredSubgroupSize = 64;
-    cp_ci.stage.pNext = &pssrss_ci;
-
-    cp_ci.stage.flags = VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT;
-    cp_ci.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    cp_ci.stage.pName = "main";
-
-    VkDescriptorSetLayoutCreateInfo dsl_ci{};
     const char* dsl_names[1] = {"DescriptorSetLayout1"};
+    auto [dsl_ci, dsl_json] =
+        getVkDescriptorSetLayoutCreateInfo(0,
+                                           {{1, VK_SHADER_STAGE_COMPUTE_BIT},
+                                            {1, VK_SHADER_STAGE_COMPUTE_BIT, immutableSamplers[0], sampler_names[0]},
+                                            {1, VK_SHADER_STAGE_COMPUTE_BIT, immutableSamplers[1], sampler_names[1]}},
+                                           std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
 
-    dsl_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-    VkDescriptorSetLayoutBindingFlagsCreateInfo dslbf_ci{};
-    dslbf_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO;
-    dslbf_ci.pNext = nullptr;
-    dslbf_ci.bindingCount = 1;
-    VkDescriptorBindingFlags bindingFlags[1] = {};
-    bindingFlags[0] = VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT;
-    dslbf_ci.pBindingFlags = bindingFlags;
-    dsl_ci.pNext = &dslbf_ci;
-    dsl_ci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT;
+    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(0), dsl_names[0]}});
 
-    dsl_ci.bindingCount = 3;
-    VkDescriptorSetLayoutBinding bindings[3] = {};
+    auto [cp_ci, cp_json] = getVkComputePipelineCreateInfo(getVkPipelineShaderStageCreateInfo(
+        0, VK_SHADER_STAGE_COMPUTE_BIT, std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo())));
 
-    bindings[0].binding = 0;
-    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    bindings[0].descriptorCount = 1;
-    bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    bindings[0].pImmutableSamplers = nullptr;
+    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0, std::make_tuple(getVkPhysicalDeviceSynchronization2Features()));
 
-    bindings[1].binding = 1;
-    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    bindings[1].descriptorCount = 1;
-    bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    bindings[1].pImmutableSamplers = &immutableSamplers[0];
-
-    bindings[2].binding = 2;
-    bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    bindings[2].descriptorCount = 1;
-    bindings[2].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    bindings[2].pImmutableSamplers = &immutableSamplers[1];
-
-    dsl_ci.pBindings = bindings;
-
-    VkPhysicalDeviceFeatures2 pdf{};
-    pdf.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-    pdf.features.robustBufferAccess = VK_TRUE;
-    VkPhysicalDeviceSynchronization2Features pdf_sync2{};
-    pdf_sync2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES;
-    pdf_sync2.synchronization2 = VK_TRUE;
-    pdf.pNext = &pdf_sync2;
-
-    VpjShaderFileName shaderFileNames[1] = {};
-    shaderFileNames[0].pFilename = "shader.comp.spv";
-    shaderFileNames[0].stage = VK_SHADER_STAGE_COMPUTE_BIT;
+    auto [shaderFileNames, shaderFileNames_json] = getShaderFileNames({{VK_SHADER_STAGE_COMPUTE_BIT, "shader.comp.spv"}});
 
     const char* enabled_extensions[1] = {"VK_EXT_robustness2"};
 
     data.enabledExtensionCount = 1;
     data.ppEnabledExtensions = enabled_extensions;
     data.computePipelineState.pComputePipeline = &cp_ci;
-    data.computePipelineState.pDescriptorSetLayouts = &dsl_ci;
     data.computePipelineState.pPipelineLayout = &pl_ci;
     data.computePipelineState.immutableSamplerCount = 2;
     data.computePipelineState.ppImmutableSamplerNames = sampler_names;
@@ -2154,8 +459,8 @@ TEST_F(Gen, ComputePipelineJSON) {
     data.computePipelineState.pDescriptorSetLayouts = &dsl_ci;
     data.computePipelineState.ppDescriptorSetLayoutNames = dsl_names;
     data.computePipelineState.pPhysicalDeviceFeatures = &pdf;
-    data.computePipelineState.shaderFileNameCount = 1;
-    data.computePipelineState.pShaderFileNames = shaderFileNames;
+    data.computePipelineState.shaderFileNameCount = (uint32_t)shaderFileNames.size();
+    data.computePipelineState.pShaderFileNames = shaderFileNames.data();
 
     data.pipelineUUID[0] = 85;
     data.pipelineUUID[1] = 43;
@@ -2166,6 +471,52 @@ TEST_F(Gen, ComputePipelineJSON) {
     data.pipelineUUID[6] = 62;
     data.pipelineUUID[7] = 24;
 
+    const std::string ref_json = R"({
+        "ComputePipelineState" :
+        {
+            "ComputePipeline" : )" +
+                                 cp_json +
+                                 R"(,
+            "DescriptorSetLayouts" :
+            [
+                {
+                    ")" + dsl_names[0] +
+                                 R"(" : )" + dsl_json + R"(
+                }
+            ],
+            "ImmutableSamplers" :
+            [
+                {
+                    ")" + sampler_names[0] +
+                                 R"(" : )" + immut_sampler_json + R"(
+                },
+                {
+                    ")" + sampler_names[1] +
+                                 R"(" : )" + ycbcr_sampler_json + R"(
+                }
+            ],
+            "PhysicalDeviceFeatures" : )" +
+                                 pdf_json + R"(,
+            "PipelineLayout" : )" +
+                                 pl_json +
+                                 R"(,
+            "ShaderFileNames" : )" +
+                                 shaderFileNames_json +
+                                 R"(,
+            "YcbcrSamplers" :
+            [
+                {
+                    ")" + ycbcr_names[0] +
+                                 R"(" : )" + ycbcr_json + R"(
+                }
+            ]
+        },
+        "EnabledExtensions" :
+        [
+            "VK_EXT_robustness2"
+        ],
+        "PipelineUUID" : [85, 43, 255, 24, 155, 64, 62, 24, 0, 0, 0, 0, 0, 0, 0, 0]
+    })";
     const char* result_json = nullptr;
 
     EXPECT_TRUE(vpjGeneratePipelineJson(generator_, &data, &result_json, &msg_));
@@ -2177,620 +528,43 @@ TEST_F(Gen, ComputePipelineJSON) {
 TEST_F(Gen, GraphicsPipelineJSON) {
     TEST_DESCRIPTION("Tests generation of a reasonably complex graphics pipeline JSON");
 
-    const std::string ref_json{R"({
-    "EnabledExtensions" : 
-    [
-        "VK_EXT_robustness2"
-    ],
-    "GraphicsPipelineState" : 
-    {
-        "DescriptorSetLayouts" : 
-        [
-            {
-                "DescriptorSetLayout1" : 
-                {
-                    "bindingCount" : 3,
-                    "flags" : "VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT",
-                    "pBindings" : 
-                    [
-                        {
-                            "binding" : 0,
-                            "descriptorCount" : 1,
-                            "descriptorType" : "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
-                            "pImmutableSamplers" : [],
-                            "stageFlags" : "VK_SHADER_STAGE_COMPUTE_BIT"
-                        },
-                        {
-                            "binding" : 1,
-                            "descriptorCount" : 1,
-                            "descriptorType" : "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
-                            "pImmutableSamplers" : 
-                            [
-                                "ImmutableSampler1"
-                            ],
-                            "stageFlags" : "VK_SHADER_STAGE_FRAGMENT_BIT"
-                        },
-                        {
-                            "binding" : 2,
-                            "descriptorCount" : 1,
-                            "descriptorType" : "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
-                            "pImmutableSamplers" : 
-                            [
-                                "YcbcrSampler1"
-                            ],
-                            "stageFlags" : "VK_SHADER_STAGE_FRAGMENT_BIT"
-                        }
-                    ],
-                    "pNext" : 
-                    {
-                        "bindingCount" : 1,
-                        "pBindingFlags" : 
-                        [
-                            "VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT"
-                        ],
-                        "pNext" : "NULL",
-                        "sType" : "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO"
-                    },
-                    "sType" : "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO"
-                }
-            }
-        ],
-)"
-                               R"(
-        "GraphicsPipeline" : 
-        {
-            "basePipelineHandle" : "",
-            "basePipelineIndex" : 0,
-            "flags" : 0,
-            "layout" : "",
-            "pColorBlendState" : "NULL",
-            "pDepthStencilState" : "NULL",
-            "pDynamicState" : "NULL",
-            "pInputAssemblyState" : "NULL",
-            "pMultisampleState" : "NULL",
-            "pNext" : "NULL",
-            "pRasterizationState" : "NULL",
-            "pStages" : 
-            [
-                {
-                    "flags" : 0,
-                    "module" : "",
-                    "pName" : "main",
-                    "pNext" : "NULL",
-                    "pSpecializationInfo" : "NULL",
-                    "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                    "stage" : "VK_SHADER_STAGE_VERTEX_BIT"
-                },
-                {
-                    "flags" : 0,
-                    "module" : "",
-                    "pName" : "main",
-                    "pNext" : 
-                    {
-                        "pNext" : "NULL",
-                        "requiredSubgroupSize" : 64,
-                        "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO"
-                    },
-                    "pSpecializationInfo" : "NULL",
-                    "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                    "stage" : "VK_SHADER_STAGE_FRAGMENT_BIT"
-                }
-            ],
-            "pTessellationState" : "NULL",
-            "pVertexInputState" : "NULL",
-            "pViewportState" : "NULL",
-            "renderPass" : "",
-            "sType" : "VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO",
-            "stageCount" : 2,
-            "subpass" : 0
-        },
-)"
-                               R"(
-        "ImmutableSamplers" : 
-        [
-            {
-                "ImmutableSampler1" : 
-                {
-                    "addressModeU" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "addressModeV" : "VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT",
-                    "addressModeW" : "VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE",
-                    "anisotropyEnable" : "VK_FALSE",
-                    "borderColor" : "VK_BORDER_COLOR_FLOAT_CUSTOM_EXT",
-                    "compareEnable" : "VK_FALSE",
-                    "compareOp" : "VK_COMPARE_OP_NEVER",
-                    "flags" : 0,
-                    "magFilter" : "VK_FILTER_CUBIC_EXT",
-                    "maxAnisotropy" : 2.0,
-                    "maxLod" : 1000.0,
-                    "minFilter" : "VK_FILTER_NEAREST",
-                    "minLod" : 0.5,
-                    "mipLodBias" : 0.5,
-                    "mipmapMode" : "VK_SAMPLER_MIPMAP_MODE_LINEAR",
-                    "pNext" : 
-                    {
-                        "pNext" : "NULL",
-                        "reductionMode" : "VK_SAMPLER_REDUCTION_MODE_MAX",
-                        "sType" : "VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO"
-                    },
-                    "sType" : "VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO",
-                    "unnormalizedCoordinates" : "VK_TRUE"
-                }
-            },
-            {
-                "YcbcrSampler1" : 
-                {
-                    "addressModeU" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "addressModeV" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "addressModeW" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "anisotropyEnable" : "VK_FALSE",
-                    "borderColor" : "VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK",
-                    "compareEnable" : "VK_FALSE",
-                    "compareOp" : "VK_COMPARE_OP_NEVER",
-                    "flags" : 0,
-                    "magFilter" : "VK_FILTER_NEAREST",
-                    "maxAnisotropy" : 0.0,
-                    "maxLod" : 0.0,
-                    "minFilter" : "VK_FILTER_NEAREST",
-                    "minLod" : 0.0,
-                    "mipLodBias" : 0.0,
-                    "mipmapMode" : "VK_SAMPLER_MIPMAP_MODE_NEAREST",
-                    "pNext" : 
-                    {
-                        "conversion" : "YcbcrConversion1",
-                        "pNext" : "NULL",
-                        "sType" : "VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO"
-                    },
-                    "sType" : "VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO",
-                    "unnormalizedCoordinates" : "VK_FALSE"
-                }
-            }
-        ],
-)"
-                               R"(
-        "PhysicalDeviceFeatures" : 
-        {
-            "features" : 
-            {
-                "alphaToOne" : "VK_FALSE",
-                "depthBiasClamp" : "VK_FALSE",
-                "depthBounds" : "VK_FALSE",
-                "depthClamp" : "VK_FALSE",
-                "drawIndirectFirstInstance" : "VK_FALSE",
-                "dualSrcBlend" : "VK_FALSE",
-                "fillModeNonSolid" : "VK_FALSE",
-                "fragmentStoresAndAtomics" : "VK_FALSE",
-                "fullDrawIndexUint32" : "VK_FALSE",
-                "geometryShader" : "VK_FALSE",
-                "imageCubeArray" : "VK_FALSE",
-                "independentBlend" : "VK_FALSE",
-                "inheritedQueries" : "VK_FALSE",
-                "largePoints" : "VK_FALSE",
-                "logicOp" : "VK_FALSE",
-                "multiDrawIndirect" : "VK_FALSE",
-                "multiViewport" : "VK_FALSE",
-                "occlusionQueryPrecise" : "VK_FALSE",
-                "pipelineStatisticsQuery" : "VK_FALSE",
-                "robustBufferAccess" : "VK_TRUE",
-                "sampleRateShading" : "VK_FALSE",
-                "samplerAnisotropy" : "VK_FALSE",
-                "shaderClipDistance" : "VK_FALSE",
-                "shaderCullDistance" : "VK_FALSE",
-                "shaderFloat64" : "VK_FALSE",
-                "shaderImageGatherExtended" : "VK_FALSE",
-                "shaderInt16" : "VK_FALSE",
-                "shaderInt64" : "VK_FALSE",
-                "shaderResourceMinLod" : "VK_FALSE",
-                "shaderResourceResidency" : "VK_FALSE",
-                "shaderSampledImageArrayDynamicIndexing" : "VK_FALSE",
-                "shaderStorageBufferArrayDynamicIndexing" : "VK_FALSE",
-                "shaderStorageImageArrayDynamicIndexing" : "VK_FALSE",
-                "shaderStorageImageExtendedFormats" : "VK_FALSE",
-                "shaderStorageImageMultisample" : "VK_FALSE",
-                "shaderStorageImageReadWithoutFormat" : "VK_FALSE",
-                "shaderStorageImageWriteWithoutFormat" : "VK_FALSE",
-                "shaderTessellationAndGeometryPointSize" : "VK_FALSE",
-                "shaderUniformBufferArrayDynamicIndexing" : "VK_FALSE",
-                "sparseBinding" : "VK_FALSE",
-                "sparseResidency16Samples" : "VK_FALSE",
-                "sparseResidency2Samples" : "VK_FALSE",
-                "sparseResidency4Samples" : "VK_FALSE",
-                "sparseResidency8Samples" : "VK_FALSE",
-                "sparseResidencyAliased" : "VK_FALSE",
-                "sparseResidencyBuffer" : "VK_FALSE",
-                "sparseResidencyImage2D" : "VK_FALSE",
-                "sparseResidencyImage3D" : "VK_FALSE",
-                "tessellationShader" : "VK_FALSE",
-                "textureCompressionASTC_LDR" : "VK_FALSE",
-                "textureCompressionBC" : "VK_FALSE",
-                "textureCompressionETC2" : "VK_FALSE",
-                "variableMultisampleRate" : "VK_FALSE",
-                "vertexPipelineStoresAndAtomics" : "VK_FALSE",
-                "wideLines" : "VK_FALSE"
-            },
-            "pNext" : 
-            {
-                "pNext" : "NULL",
-                "sType" : "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES",
-                "synchronization2" : "VK_TRUE"
-            },
-            "sType" : "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2"
-        },
-)"
-                               R"(
-        "PipelineLayout" : 
-        {
-            "flags" : 0,
-            "pNext" : "NULL",
-            "pPushConstantRanges" : 
-            [
-                {
-                    "offset" : 0,
-                    "size" : 4,
-                    "stageFlags" : "VK_SHADER_STAGE_COMPUTE_BIT"
-                }
-            ],
-            "pSetLayouts" : 
-            [
-                "DescriptorSetLayout1"
-            ],
-            "pushConstantRangeCount" : 1,
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO",
-            "setLayoutCount" : 1
-        },
-)"
-                               R"(
-        "Renderpass" : 
-        {
-            "attachmentCount" : 2,
-            "dependencyCount" : 2,
-            "flags" : 0,
-            "pAttachments" : 
-            [
-                {
-                    "finalLayout" : "VK_IMAGE_LAYOUT_PRESENT_SRC_KHR",
-                    "flags" : 0,
-                    "format" : "VK_FORMAT_R8G8B8A8_UNORM",
-                    "initialLayout" : "VK_IMAGE_LAYOUT_UNDEFINED",
-                    "loadOp" : "VK_ATTACHMENT_LOAD_OP_CLEAR",
-                    "samples" : "VK_SAMPLE_COUNT_1_BIT",
-                    "stencilLoadOp" : "VK_ATTACHMENT_LOAD_OP_DONT_CARE",
-                    "stencilStoreOp" : "VK_ATTACHMENT_STORE_OP_DONT_CARE",
-                    "storeOp" : "VK_ATTACHMENT_STORE_OP_STORE"
-                },
-                {
-                    "finalLayout" : "VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL",
-                    "flags" : 0,
-                    "format" : "VK_FORMAT_D16_UNORM",
-                    "initialLayout" : "VK_IMAGE_LAYOUT_UNDEFINED",
-                    "loadOp" : "VK_ATTACHMENT_LOAD_OP_CLEAR",
-                    "samples" : "VK_SAMPLE_COUNT_1_BIT",
-                    "stencilLoadOp" : "VK_ATTACHMENT_LOAD_OP_DONT_CARE",
-                    "stencilStoreOp" : "VK_ATTACHMENT_STORE_OP_DONT_CARE",
-                    "storeOp" : "VK_ATTACHMENT_STORE_OP_DONT_CARE"
-                }
-            ],
-            "pDependencies" : 
-            [
-                {
-                    "dependencyFlags" : 0,
-                    "dstAccessMask" : "VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT",
-                    "dstStageMask" : "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
-                    "dstSubpass" : 0,
-                    "srcAccessMask" : "VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT",
-                    "srcStageMask" : "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
-                    "srcSubpass" : 4294967295
-                },
-                {
-                    "dependencyFlags" : 0,
-                    "dstAccessMask" : "VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT",
-                    "dstStageMask" : "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
-                    "dstSubpass" : 0,
-                    "srcAccessMask" : 0,
-                    "srcStageMask" : "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
-                    "srcSubpass" : 4294967295
-                }
-            ],
-            "pNext" : "NULL",
-            "pSubpasses" : 
-            [
-                {
-                    "colorAttachmentCount" : 1,
-                    "flags" : 0,
-                    "inputAttachmentCount" : 0,
-                    "pColorAttachments" : 
-                    [
-                        {
-                            "attachment" : 0,
-                            "layout" : "VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL"
-                        }
-                    ],
-                    "pDepthStencilAttachment" : 
-                    {
-                        "attachment" : 1,
-                        "layout" : "VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL"
-                    },
-                    "pInputAttachments" : "NULL",
-                    "pPreserveAttachments" : "NULL",
-                    "pResolveAttachments" : "NULL",
-                    "pipelineBindPoint" : "VK_PIPELINE_BIND_POINT_GRAPHICS",
-                    "preserveAttachmentCount" : 0
-                }
-            ],
-            "sType" : "VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO",
-            "subpassCount" : 1
-        },
-)"
-                               R"(
-        "ShaderFileNames" : 
-        [
-            {
-                "filename" : "shader.vert.spv",
-                "stage" : "VK_SHADER_STAGE_VERTEX_BIT"
-            },
-            {
-                "filename" : "shader.frag.spv",
-                "stage" : "VK_SHADER_STAGE_FRAGMENT_BIT"
-            }
-        ],
-        "YcbcrSamplers" : 
-        [
-            {
-                "YcbcrConversion1" : 
-                {
-                    "chromaFilter" : "VK_FILTER_CUBIC_EXT",
-                    "components" : 
-                    {
-                        "a" : "VK_COMPONENT_SWIZZLE_R",
-                        "b" : "VK_COMPONENT_SWIZZLE_G",
-                        "g" : "VK_COMPONENT_SWIZZLE_B",
-                        "r" : "VK_COMPONENT_SWIZZLE_A"
-                    },
-                    "forceExplicitReconstruction" : "VK_TRUE",
-                    "format" : "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16",
-                    "pNext" : "NULL",
-                    "sType" : "VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO",
-                    "xChromaOffset" : "VK_CHROMA_LOCATION_COSITED_EVEN",
-                    "yChromaOffset" : "VK_CHROMA_LOCATION_MIDPOINT",
-                    "ycbcrModel" : "VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020",
-                    "ycbcrRange" : "VK_SAMPLER_YCBCR_RANGE_ITU_NARROW"
-                }
-            }
-        ]
-    },
-    "PipelineUUID" : 
-    [
-        85,
-        43,
-        255,
-        24,
-        155,
-        64,
-        62,
-        24,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0
-    ]
-})"};
-
     VpjData data{};
 
-    VkRenderPassCreateInfo renderPass = {};
-    data.graphicsPipelineState.pRenderPass = &renderPass;
-    renderPass.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-    renderPass.pNext = nullptr;
-    renderPass.flags = 0;
-    renderPass.attachmentCount = 2;
-    VkAttachmentDescription attachments[2] = {{}, {}};
-    renderPass.pAttachments = attachments;
-    attachments[0].flags = 0;
-    attachments[0].format = VK_FORMAT_R8G8B8A8_UNORM;
-    attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
-    attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-    attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-    attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    attachments[0].finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-    attachments[1].flags = 0;
-    attachments[1].format = VK_FORMAT_D16_UNORM;
-    attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
-    attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-    attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    attachments[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    attachments[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    attachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-    renderPass.subpassCount = 1;
-    VkSubpassDescription subpasses[1] = {{}};
-    renderPass.pSubpasses = subpasses;
-    subpasses[0].flags = 0;
-    subpasses[0].pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-    subpasses[0].inputAttachmentCount = 0;
-    subpasses[0].pInputAttachments = nullptr;
-    subpasses[0].colorAttachmentCount = 1;
-    VkAttachmentReference colorAttachments[1] = {{}};
-    colorAttachments[0].attachment = 0;
-    colorAttachments[0].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-    subpasses[0].pColorAttachments = colorAttachments;
-    subpasses[0].pResolveAttachments = nullptr;
-    VkAttachmentReference depthStencilAttachment[1] = {{}};
-    depthStencilAttachment[0].attachment = 1;
-    depthStencilAttachment[0].layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-    subpasses[0].pDepthStencilAttachment = depthStencilAttachment;
-    subpasses[0].preserveAttachmentCount = 0;
-    subpasses[0].pPreserveAttachments = nullptr;
-    renderPass.dependencyCount = 2;
-    VkSubpassDependency dependencies[2] = {{}, {}};
-    dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
-    dependencies[0].dstSubpass = 0;
-    dependencies[0].srcStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
-    dependencies[0].dstStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
-    dependencies[0].srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-    dependencies[0].dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-    dependencies[0].dependencyFlags = 0;
-    dependencies[1].srcSubpass = VK_SUBPASS_EXTERNAL;
-    dependencies[1].dstSubpass = 0;
-    dependencies[1].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dependencies[1].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dependencies[1].srcAccessMask = 0;
-    dependencies[1].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
-    dependencies[1].dependencyFlags = 0;
-    renderPass.pDependencies = dependencies;
-
-    VkSamplerYcbcrConversionCreateInfo ycbcr_ci;
     const char* ycbcr_names[1] = {"YcbcrConversion1"};
-    ycbcr_ci.sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO;
-#ifdef VK_USE_PLATFORM_SCREEN_QNX
-    VkExternalFormatQNX ef_qnx{};
-    ef_qnx.sType = VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_QNX;
-    ef_qnx.pNext = nullptr;
-    ef_qnx.externalFormat = 10;
-    ycbcr_ci.pNext = &ef_qnx;
-#else
-    ycbcr_ci.pNext = nullptr;
-#endif  // VK_USE_PLATFORM_SCREEN_QNX
-    ycbcr_ci.format = VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16;
-    ycbcr_ci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020;
-    ycbcr_ci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_NARROW;
-    ycbcr_ci.components.r = VK_COMPONENT_SWIZZLE_A;
-    ycbcr_ci.components.g = VK_COMPONENT_SWIZZLE_B;
-    ycbcr_ci.components.b = VK_COMPONENT_SWIZZLE_G;
-    ycbcr_ci.components.a = VK_COMPONENT_SWIZZLE_R;
-    ycbcr_ci.xChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
-    ycbcr_ci.yChromaOffset = VK_CHROMA_LOCATION_MIDPOINT;
-    ycbcr_ci.chromaFilter = VK_FILTER_CUBIC_EXT;
-    ycbcr_ci.forceExplicitReconstruction = VK_TRUE;
+    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
+    auto ycbcr_conversion = VkSamplerYcbcrConversion(0);
 
-    VkSamplerCreateInfo sampler_ci[2] = {};
     const char* sampler_names[2] = {"ImmutableSampler1", "YcbcrSampler1"};
-
-    VkSamplerYcbcrConversionInfo ycbcrConversionInfo[1] = {};
-
-    ycbcrConversionInfo[0].sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO;
-    ycbcrConversionInfo[0].conversion = VkSamplerYcbcrConversion(0);
-
+    auto [immut_sampler_ci, immut_sampler_json] =
+        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerReductionModeCreateInfo(VK_SAMPLER_REDUCTION_MODE_MAX)));
+    auto [ycbcr_sampler_ci, ycbcr_sampler_json] =
+        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerYcbcrConversionInfo(ycbcr_conversion, ycbcr_names[0])));
+    VkSamplerCreateInfo sampler_ci[2] = {*immut_sampler_ci.ptr(), *ycbcr_sampler_ci.ptr()};
     VkSampler immutableSamplers[2] = {VkSampler(0), VkSampler(1)};
 
-    sampler_ci[0].sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    VkSamplerReductionModeCreateInfo srm_ci{};
-    srm_ci.sType = VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO;
-    srm_ci.pNext = nullptr;
-    srm_ci.reductionMode = VK_SAMPLER_REDUCTION_MODE_MAX;
-    sampler_ci[0].pNext = &srm_ci;
-    sampler_ci[0].flags = 0;
-    sampler_ci[0].magFilter = VK_FILTER_CUBIC_EXT;
-    sampler_ci[0].minFilter = VK_FILTER_NEAREST;
-    sampler_ci[0].mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-    sampler_ci[0].addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-    sampler_ci[0].addressModeV = VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
-    sampler_ci[0].addressModeW = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
-    sampler_ci[0].mipLodBias = 0.5f;
-    sampler_ci[0].anisotropyEnable = VK_FALSE;
-    sampler_ci[0].maxAnisotropy = 2.0f;
-    sampler_ci[0].compareEnable = VK_FALSE;
-    sampler_ci[0].compareOp = VK_COMPARE_OP_NEVER;
-    sampler_ci[0].minLod = 0.5f;
-    sampler_ci[0].maxLod = VK_LOD_CLAMP_NONE;
-    sampler_ci[0].borderColor = VK_BORDER_COLOR_FLOAT_CUSTOM_EXT;
-    sampler_ci[0].unnormalizedCoordinates = VK_TRUE;
-
-    sampler_ci[1].sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    sampler_ci[1].pNext = &ycbcrConversionInfo;
-
-    VkGraphicsPipelineCreateInfo gp_ci = {};
-    data.graphicsPipelineState.pGraphicsPipeline = &gp_ci;
-    gp_ci.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    gp_ci.pNext = nullptr;
-    gp_ci.flags = 0;
-    gp_ci.stageCount = 2;
-    VkPipelineShaderStageCreateInfo stages[2] = {{}, {}};
-    gp_ci.pStages = stages;
-    stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    stages[0].pNext = nullptr;
-    stages[0].flags = 0;
-    stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-    stages[0].module = reinterpret_cast<VkShaderModule>(38);
-    stages[0].pName = "main";
-    stages[0].pSpecializationInfo = nullptr;
-    stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    VkPipelineShaderStageRequiredSubgroupSizeCreateInfo pssrss_ci{};
-    pssrss_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO;
-    pssrss_ci.pNext = nullptr;
-    pssrss_ci.requiredSubgroupSize = 64;
-    stages[1].pNext = &pssrss_ci;
-    stages[1].flags = 0;
-    stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    stages[1].module = reinterpret_cast<VkShaderModule>(39);
-    stages[1].pName = "main";
-    stages[1].pSpecializationInfo = nullptr;
-
-    VkPipelineLayoutCreateInfo pl_ci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
-
-    VkDescriptorSetLayout setLayouts[3] = {VkDescriptorSetLayout(0)};
-    pl_ci.setLayoutCount = 1;
-    pl_ci.pSetLayouts = setLayouts;
-    VkPushConstantRange pushConstantRanges[1] = {};
-    pl_ci.pushConstantRangeCount = 1;
-    pushConstantRanges[0].size = 4;
-    pushConstantRanges[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    pl_ci.pPushConstantRanges = pushConstantRanges;
-
-    VkDescriptorSetLayoutCreateInfo dsl_ci{};
     const char* dsl_names[1] = {"DescriptorSetLayout1"};
+    auto [dsl_ci, dsl_json] =
+        getVkDescriptorSetLayoutCreateInfo(0,
+                                           {{1, VK_SHADER_STAGE_VERTEX_BIT},
+                                            {1, VK_SHADER_STAGE_FRAGMENT_BIT, immutableSamplers[0], sampler_names[0]},
+                                            {1, VK_SHADER_STAGE_FRAGMENT_BIT, immutableSamplers[1], sampler_names[1]}},
+                                           std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
 
-    dsl_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-    VkDescriptorSetLayoutBindingFlagsCreateInfo dslbf_ci{};
-    dslbf_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO;
-    dslbf_ci.pNext = nullptr;
-    dslbf_ci.bindingCount = 1;
-    VkDescriptorBindingFlags bindingFlags[1] = {};
-    bindingFlags[0] = VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT;
-    dslbf_ci.pBindingFlags = bindingFlags;
-    dsl_ci.pNext = &dslbf_ci;
-    dsl_ci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT;
+    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(0), dsl_names[0]}});
 
-    dsl_ci.bindingCount = 3;
-    VkDescriptorSetLayoutBinding bindings[3] = {};
+    auto [renderPass, renderPass_json] = getVkRenderPassCreateInfo(0);
 
-    bindings[0].binding = 0;
-    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    bindings[0].descriptorCount = 1;
-    bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    bindings[0].pImmutableSamplers = nullptr;
+    auto [gp_ci, gp_json] = getVkGraphicsPipelineCreateInfo(
+        0, {getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_VERTEX_BIT),
+            getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_FRAGMENT_BIT,
+                                               std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo()))});
 
-    bindings[1].binding = 1;
-    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    bindings[1].descriptorCount = 1;
-    bindings[1].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    bindings[1].pImmutableSamplers = &immutableSamplers[0];
+    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0, std::make_tuple(getVkPhysicalDeviceSynchronization2Features()));
 
-    bindings[2].binding = 2;
-    bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    bindings[2].descriptorCount = 1;
-    bindings[2].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    bindings[2].pImmutableSamplers = &immutableSamplers[1];
-
-    dsl_ci.pBindings = bindings;
-
-    VkPhysicalDeviceFeatures2 pdf{};
-    pdf.features.robustBufferAccess = VK_TRUE;
-    pdf.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-    VkPhysicalDeviceSynchronization2Features pdf_sync2{};
-    pdf_sync2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES;
-    pdf_sync2.synchronization2 = VK_TRUE;
-    pdf.pNext = &pdf_sync2;
-
-    VpjShaderFileName shaderFileNames[2] = {};
-    shaderFileNames[0].pFilename = "shader.vert.spv";
-    shaderFileNames[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-    shaderFileNames[1].pFilename = "shader.frag.spv";
-    shaderFileNames[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    auto [shaderFileNames, shaderFileNames_json] = getShaderFileNames({
+        {VK_SHADER_STAGE_VERTEX_BIT, "shader.vert.spv"},
+        {VK_SHADER_STAGE_FRAGMENT_BIT, "shader.frag.spv"},
+    });
 
     const char* enabled_extensions[1] = {"VK_EXT_robustness2"};
 
@@ -2798,7 +572,6 @@ TEST_F(Gen, GraphicsPipelineJSON) {
     data.ppEnabledExtensions = enabled_extensions;
     data.graphicsPipelineState.pGraphicsPipeline = &gp_ci;
     data.graphicsPipelineState.pRenderPass = &renderPass;
-    data.graphicsPipelineState.pDescriptorSetLayouts = &dsl_ci;
     data.graphicsPipelineState.pPipelineLayout = &pl_ci;
     data.graphicsPipelineState.immutableSamplerCount = 2;
     data.graphicsPipelineState.ppImmutableSamplerNames = sampler_names;
@@ -2810,8 +583,8 @@ TEST_F(Gen, GraphicsPipelineJSON) {
     data.graphicsPipelineState.pDescriptorSetLayouts = &dsl_ci;
     data.graphicsPipelineState.ppDescriptorSetLayoutNames = dsl_names;
     data.graphicsPipelineState.pPhysicalDeviceFeatures = &pdf;
-    data.graphicsPipelineState.shaderFileNameCount = 2;
-    data.graphicsPipelineState.pShaderFileNames = shaderFileNames;
+    data.graphicsPipelineState.shaderFileNameCount = (uint32_t)shaderFileNames.size();
+    data.graphicsPipelineState.pShaderFileNames = shaderFileNames.data();
 
     data.pipelineUUID[0] = 85;
     data.pipelineUUID[1] = 43;
@@ -2822,6 +595,54 @@ TEST_F(Gen, GraphicsPipelineJSON) {
     data.pipelineUUID[6] = 62;
     data.pipelineUUID[7] = 24;
 
+    const std::string ref_json = R"({
+        "GraphicsPipelineState" :
+        {
+            "Renderpass": )" + renderPass_json +
+                                 R"(,
+            "GraphicsPipeline" : )" +
+                                 gp_json +
+                                 R"(,
+            "DescriptorSetLayouts" :
+            [
+                {
+                    ")" + dsl_names[0] +
+                                 R"(" : )" + dsl_json + R"(
+                }
+            ],
+            "ImmutableSamplers" :
+            [
+                {
+                    ")" + sampler_names[0] +
+                                 R"(" : )" + immut_sampler_json + R"(
+                },
+                {
+                    ")" + sampler_names[1] +
+                                 R"(" : )" + ycbcr_sampler_json + R"(
+                }
+            ],
+            "PhysicalDeviceFeatures" : )" +
+                                 pdf_json + R"(,
+            "PipelineLayout" : )" +
+                                 pl_json +
+                                 R"(,
+            "ShaderFileNames" : )" +
+                                 shaderFileNames_json +
+                                 R"(,
+            "YcbcrSamplers" :
+            [
+                {
+                    ")" + ycbcr_names[0] +
+                                 R"(" : )" + ycbcr_json + R"(
+                }
+            ]
+        },
+        "EnabledExtensions" :
+        [
+            "VK_EXT_robustness2"
+        ],
+        "PipelineUUID" : [85, 43, 255, 24, 155, 64, 62, 24, 0, 0, 0, 0, 0, 0, 0, 0]
+    })";
     const char* result_json = nullptr;
 
     EXPECT_TRUE(vpjGeneratePipelineJson(generator_, &data, &result_json, &msg_));
@@ -2833,443 +654,44 @@ TEST_F(Gen, GraphicsPipelineJSON) {
 TEST_F(Gen, ComputePipelineJSONWithMD5) {
     TEST_DESCRIPTION("Tests generating pipeline JSON with MD5 UUID for a compute pipeline");
 
-    const std::string ref_json{R"({
-    "ComputePipelineState" : 
-    {
-        "ComputePipeline" : 
-        {
-            "basePipelineHandle" : "",
-            "basePipelineIndex" : 0,
-            "flags" : 0,
-            "layout" : "",
-            "pNext" : "NULL",
-            "sType" : "VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO",
-            "stage" : 
-            {
-                "flags" : "VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT",
-                "module" : "",
-                "pName" : "main",
-                "pNext" : 
-                {
-                    "pNext" : "NULL",
-                    "requiredSubgroupSize" : 64,
-                    "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO"
-                },
-                "pSpecializationInfo" : "NULL",
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                "stage" : "VK_SHADER_STAGE_COMPUTE_BIT"
-            }
-        },
-)"
-                               R"(
-        "DescriptorSetLayouts" : 
-        [
-            {
-                "DescriptorSetLayout1" : 
-                {
-                    "bindingCount" : 3,
-                    "flags" : "VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT",
-                    "pBindings" : 
-                    [
-                        {
-                            "binding" : 0,
-                            "descriptorCount" : 1,
-                            "descriptorType" : "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
-                            "pImmutableSamplers" : [],
-                            "stageFlags" : "VK_SHADER_STAGE_COMPUTE_BIT"
-                        },
-                        {
-                            "binding" : 1,
-                            "descriptorCount" : 1,
-                            "descriptorType" : "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
-                            "pImmutableSamplers" : 
-                            [
-                                "ImmutableSampler1"
-                            ],
-                            "stageFlags" : "VK_SHADER_STAGE_COMPUTE_BIT"
-                        },
-                        {
-                            "binding" : 2,
-                            "descriptorCount" : 1,
-                            "descriptorType" : "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
-                            "pImmutableSamplers" : 
-                            [
-                                "YcbcrSampler1"
-                            ],
-                            "stageFlags" : "VK_SHADER_STAGE_COMPUTE_BIT"
-                        }
-                    ],
-                    "pNext" : 
-                    {
-                        "bindingCount" : 1,
-                        "pBindingFlags" : 
-                        [
-                            "VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT"
-                        ],
-                        "pNext" : "NULL",
-                        "sType" : "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO"
-                    },
-                    "sType" : "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO"
-                }
-            }
-        ],
-)"
-                               R"(
-        "ImmutableSamplers" : 
-        [
-            {
-                "ImmutableSampler1" : 
-                {
-                    "addressModeU" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "addressModeV" : "VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT",
-                    "addressModeW" : "VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE",
-                    "anisotropyEnable" : "VK_FALSE",
-                    "borderColor" : "VK_BORDER_COLOR_FLOAT_CUSTOM_EXT",
-                    "compareEnable" : "VK_FALSE",
-                    "compareOp" : "VK_COMPARE_OP_NEVER",
-                    "flags" : 0,
-                    "magFilter" : "VK_FILTER_CUBIC_EXT",
-                    "maxAnisotropy" : 2.0,
-                    "maxLod" : 1000.0,
-                    "minFilter" : "VK_FILTER_NEAREST",
-                    "minLod" : 0.5,
-                    "mipLodBias" : 0.5,
-                    "mipmapMode" : "VK_SAMPLER_MIPMAP_MODE_LINEAR",
-                    "pNext" : 
-                    {
-                        "pNext" : "NULL",
-                        "reductionMode" : "VK_SAMPLER_REDUCTION_MODE_MAX",
-                        "sType" : "VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO"
-                    },
-                    "sType" : "VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO",
-                    "unnormalizedCoordinates" : "VK_TRUE"
-                }
-            },
-            {
-                "YcbcrSampler1" : 
-                {
-                    "addressModeU" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "addressModeV" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "addressModeW" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "anisotropyEnable" : "VK_FALSE",
-                    "borderColor" : "VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK",
-                    "compareEnable" : "VK_FALSE",
-                    "compareOp" : "VK_COMPARE_OP_NEVER",
-                    "flags" : 0,
-                    "magFilter" : "VK_FILTER_NEAREST",
-                    "maxAnisotropy" : 0.0,
-                    "maxLod" : 0.0,
-                    "minFilter" : "VK_FILTER_NEAREST",
-                    "minLod" : 0.0,
-                    "mipLodBias" : 0.0,
-                    "mipmapMode" : "VK_SAMPLER_MIPMAP_MODE_NEAREST",
-                    "pNext" : 
-                    {
-                        "conversion" : "YcbcrConversion1",
-                        "pNext" : "NULL",
-                        "sType" : "VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO"
-                    },
-                    "sType" : "VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO",
-                    "unnormalizedCoordinates" : "VK_FALSE"
-                }
-            }
-        ],
-)"
-                               R"(
-        "PhysicalDeviceFeatures" : 
-        {
-            "features" : 
-            {
-                "alphaToOne" : "VK_FALSE",
-                "depthBiasClamp" : "VK_FALSE",
-                "depthBounds" : "VK_FALSE",
-                "depthClamp" : "VK_FALSE",
-                "drawIndirectFirstInstance" : "VK_FALSE",
-                "dualSrcBlend" : "VK_FALSE",
-                "fillModeNonSolid" : "VK_FALSE",
-                "fragmentStoresAndAtomics" : "VK_FALSE",
-                "fullDrawIndexUint32" : "VK_FALSE",
-                "geometryShader" : "VK_FALSE",
-                "imageCubeArray" : "VK_FALSE",
-                "independentBlend" : "VK_FALSE",
-                "inheritedQueries" : "VK_FALSE",
-                "largePoints" : "VK_FALSE",
-                "logicOp" : "VK_FALSE",
-                "multiDrawIndirect" : "VK_FALSE",
-                "multiViewport" : "VK_FALSE",
-                "occlusionQueryPrecise" : "VK_FALSE",
-                "pipelineStatisticsQuery" : "VK_FALSE",
-                "robustBufferAccess" : "VK_FALSE",
-                "sampleRateShading" : "VK_FALSE",
-                "samplerAnisotropy" : "VK_FALSE",
-                "shaderClipDistance" : "VK_FALSE",
-                "shaderCullDistance" : "VK_FALSE",
-                "shaderFloat64" : "VK_FALSE",
-                "shaderImageGatherExtended" : "VK_FALSE",
-                "shaderInt16" : "VK_FALSE",
-                "shaderInt64" : "VK_FALSE",
-                "shaderResourceMinLod" : "VK_FALSE",
-                "shaderResourceResidency" : "VK_FALSE",
-                "shaderSampledImageArrayDynamicIndexing" : "VK_FALSE",
-                "shaderStorageBufferArrayDynamicIndexing" : "VK_FALSE",
-                "shaderStorageImageArrayDynamicIndexing" : "VK_FALSE",
-                "shaderStorageImageExtendedFormats" : "VK_FALSE",
-                "shaderStorageImageMultisample" : "VK_FALSE",
-                "shaderStorageImageReadWithoutFormat" : "VK_FALSE",
-                "shaderStorageImageWriteWithoutFormat" : "VK_FALSE",
-                "shaderTessellationAndGeometryPointSize" : "VK_FALSE",
-                "shaderUniformBufferArrayDynamicIndexing" : "VK_FALSE",
-                "sparseBinding" : "VK_FALSE",
-                "sparseResidency16Samples" : "VK_FALSE",
-                "sparseResidency2Samples" : "VK_FALSE",
-                "sparseResidency4Samples" : "VK_FALSE",
-                "sparseResidency8Samples" : "VK_FALSE",
-                "sparseResidencyAliased" : "VK_FALSE",
-                "sparseResidencyBuffer" : "VK_FALSE",
-                "sparseResidencyImage2D" : "VK_FALSE",
-                "sparseResidencyImage3D" : "VK_FALSE",
-                "tessellationShader" : "VK_FALSE",
-                "textureCompressionASTC_LDR" : "VK_FALSE",
-                "textureCompressionBC" : "VK_FALSE",
-                "textureCompressionETC2" : "VK_FALSE",
-                "variableMultisampleRate" : "VK_FALSE",
-                "vertexPipelineStoresAndAtomics" : "VK_FALSE",
-                "wideLines" : "VK_FALSE"
-            },
-            "pNext" : 
-            {
-                "pNext" : "NULL",
-                "sType" : "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES",
-                "synchronization2" : "VK_TRUE"
-            },
-            "sType" : "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2"
-        },
-)"
-                               R"(
-        "PipelineLayout" : 
-        {
-            "flags" : 0,
-            "pNext" : "NULL",
-            "pPushConstantRanges" : 
-            [
-                {
-                    "offset" : 0,
-                    "size" : 4,
-                    "stageFlags" : "VK_SHADER_STAGE_COMPUTE_BIT"
-                }
-            ],
-            "pSetLayouts" : 
-            [
-                "DescriptorSetLayout1"
-            ],
-            "pushConstantRangeCount" : 1,
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO",
-            "setLayoutCount" : 1
-        },
-        "ShaderFileNames" : 
-        [
-            {
-                "filename" : "shader.comp.spv",
-                "stage" : "VK_SHADER_STAGE_COMPUTE_BIT"
-            }
-        ],
-        "YcbcrSamplers" : 
-        [
-            {
-                "YcbcrConversion1" : 
-                {
-                    "chromaFilter" : "VK_FILTER_CUBIC_EXT",
-                    "components" : 
-                    {
-                        "a" : "VK_COMPONENT_SWIZZLE_R",
-                        "b" : "VK_COMPONENT_SWIZZLE_G",
-                        "g" : "VK_COMPONENT_SWIZZLE_B",
-                        "r" : "VK_COMPONENT_SWIZZLE_A"
-                    },
-                    "forceExplicitReconstruction" : "VK_TRUE",
-                    "format" : "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16",
-                    "pNext" : "NULL",
-                    "sType" : "VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO",
-                    "xChromaOffset" : "VK_CHROMA_LOCATION_COSITED_EVEN",
-                    "yChromaOffset" : "VK_CHROMA_LOCATION_MIDPOINT",
-                    "ycbcrModel" : "VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020",
-                    "ycbcrRange" : "VK_SAMPLER_YCBCR_RANGE_ITU_NARROW"
-                }
-            }
-        ]
-    },
-    "EnabledExtensions" : 
-    [
-        "VK_EXT_robustness2"
-    ],
-    "PipelineUUID" :
-    [
-        173,
-        219,
-        118,
-        247,
-        216,
-        178,
-        101,
-        146,
-        185,
-        23,
-        86,
-        164,
-        204,
-        27,
-        25,
-        250
-    ]
-})"};
-
     VpjData data{};
 
-    VkSamplerYcbcrConversionCreateInfo ycbcr_ci;
     const char* ycbcr_names[1] = {"YcbcrConversion1"};
-    ycbcr_ci.sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO;
-#ifdef VK_USE_PLATFORM_SCREEN_QNX
-    VkExternalFormatQNX ef_qnx{};
-    ef_qnx.sType = VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_QNX;
-    ef_qnx.pNext = nullptr;
-    ef_qnx.externalFormat = 10;
-    ycbcr_ci.pNext = &ef_qnx;
-#else
-    ycbcr_ci.pNext = nullptr;
-#endif  // VK_USE_PLATFORM_SCREEN_QNX
-    ycbcr_ci.format = VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16;
-    ycbcr_ci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020;
-    ycbcr_ci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_NARROW;
-    ycbcr_ci.components.r = VK_COMPONENT_SWIZZLE_A;
-    ycbcr_ci.components.g = VK_COMPONENT_SWIZZLE_B;
-    ycbcr_ci.components.b = VK_COMPONENT_SWIZZLE_G;
-    ycbcr_ci.components.a = VK_COMPONENT_SWIZZLE_R;
-    ycbcr_ci.xChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
-    ycbcr_ci.yChromaOffset = VK_CHROMA_LOCATION_MIDPOINT;
-    ycbcr_ci.chromaFilter = VK_FILTER_CUBIC_EXT;
-    ycbcr_ci.forceExplicitReconstruction = VK_TRUE;
+    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
+    auto ycbcr_conversion = VkSamplerYcbcrConversion(0);
 
-    VkSamplerCreateInfo sampler_ci[2] = {};
     const char* sampler_names[2] = {"ImmutableSampler1", "YcbcrSampler1"};
-
-    VkSamplerYcbcrConversionInfo ycbcrConversionInfo[1] = {};
-
-    ycbcrConversionInfo[0].sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO;
-    ycbcrConversionInfo[0].conversion = VkSamplerYcbcrConversion(0);
-
+    auto [immut_sampler_ci, immut_sampler_json] =
+        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerReductionModeCreateInfo(VK_SAMPLER_REDUCTION_MODE_MAX)));
+    auto [ycbcr_sampler_ci, ycbcr_sampler_json] =
+        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerYcbcrConversionInfo(ycbcr_conversion, ycbcr_names[0])));
+    VkSamplerCreateInfo sampler_ci[2] = {*immut_sampler_ci.ptr(), *ycbcr_sampler_ci.ptr()};
     VkSampler immutableSamplers[2] = {VkSampler(0), VkSampler(1)};
 
-    sampler_ci[0].sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    VkSamplerReductionModeCreateInfo srm_ci{};
-    srm_ci.sType = VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO;
-    srm_ci.pNext = nullptr;
-    srm_ci.reductionMode = VK_SAMPLER_REDUCTION_MODE_MAX;
-    sampler_ci[0].pNext = &srm_ci;
-    sampler_ci[0].flags = 0;
-    sampler_ci[0].magFilter = VK_FILTER_CUBIC_EXT;
-    sampler_ci[0].minFilter = VK_FILTER_NEAREST;
-    sampler_ci[0].mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-    sampler_ci[0].addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-    sampler_ci[0].addressModeV = VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
-    sampler_ci[0].addressModeW = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
-    sampler_ci[0].mipLodBias = 0.5f;
-    sampler_ci[0].anisotropyEnable = VK_FALSE;
-    sampler_ci[0].maxAnisotropy = 2.0f;
-    sampler_ci[0].compareEnable = VK_FALSE;
-    sampler_ci[0].compareOp = VK_COMPARE_OP_NEVER;
-    sampler_ci[0].minLod = 0.5f;
-    sampler_ci[0].maxLod = VK_LOD_CLAMP_NONE;
-    sampler_ci[0].borderColor = VK_BORDER_COLOR_FLOAT_CUSTOM_EXT;
-    sampler_ci[0].unnormalizedCoordinates = VK_TRUE;
-
-    sampler_ci[1].sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    sampler_ci[1].pNext = &ycbcrConversionInfo;
-
-    VkComputePipelineCreateInfo cp_ci{};
-    cp_ci.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
-    cp_ci.pNext = nullptr;
-    cp_ci.flags = 0;
-    cp_ci.stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-
-    VkPipelineLayoutCreateInfo pl_ci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
-
-    VkDescriptorSetLayout setLayouts[3] = {VkDescriptorSetLayout(0)};
-    pl_ci.setLayoutCount = 1;
-    pl_ci.pSetLayouts = setLayouts;
-    VkPushConstantRange pushConstantRanges[1] = {};
-    pl_ci.pushConstantRangeCount = 1;
-    pushConstantRanges[0].size = 4;
-    pushConstantRanges[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    pl_ci.pPushConstantRanges = pushConstantRanges;
-
-    VkPipelineShaderStageRequiredSubgroupSizeCreateInfo pssrss_ci{};
-    pssrss_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO;
-    pssrss_ci.pNext = nullptr;
-    pssrss_ci.requiredSubgroupSize = 64;
-    cp_ci.stage.pNext = &pssrss_ci;
-
-    cp_ci.stage.flags = VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT;
-    cp_ci.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    cp_ci.stage.pName = "main";
-
-    VkDescriptorSetLayoutCreateInfo dsl_ci{};
     const char* dsl_names[1] = {"DescriptorSetLayout1"};
+    auto [dsl_ci, dsl_json] =
+        getVkDescriptorSetLayoutCreateInfo(0,
+                                           {{1, VK_SHADER_STAGE_COMPUTE_BIT},
+                                            {1, VK_SHADER_STAGE_COMPUTE_BIT, immutableSamplers[0], sampler_names[0]},
+                                            {1, VK_SHADER_STAGE_COMPUTE_BIT, immutableSamplers[1], sampler_names[1]}},
+                                           std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
 
-    dsl_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-    VkDescriptorSetLayoutBindingFlagsCreateInfo dslbf_ci{};
-    dslbf_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO;
-    dslbf_ci.pNext = nullptr;
-    dslbf_ci.bindingCount = 1;
-    VkDescriptorBindingFlags bindingFlags[1] = {};
-    bindingFlags[0] = VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT;
-    dslbf_ci.pBindingFlags = bindingFlags;
-    dsl_ci.pNext = &dslbf_ci;
-    dsl_ci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT;
+    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(0), dsl_names[0]}});
 
-    dsl_ci.bindingCount = 3;
-    VkDescriptorSetLayoutBinding bindings[3] = {};
+    auto [cp_ci, cp_json] = getVkComputePipelineCreateInfo(getVkPipelineShaderStageCreateInfo(
+        0, VK_SHADER_STAGE_COMPUTE_BIT, std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo())));
 
-    bindings[0].binding = 0;
-    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    bindings[0].descriptorCount = 1;
-    bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    bindings[0].pImmutableSamplers = nullptr;
-
-    bindings[1].binding = 1;
-    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    bindings[1].descriptorCount = 1;
-    bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    bindings[1].pImmutableSamplers = &immutableSamplers[0];
-
-    bindings[2].binding = 2;
-    bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    bindings[2].descriptorCount = 1;
-    bindings[2].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    bindings[2].pImmutableSamplers = &immutableSamplers[1];
-
-    dsl_ci.pBindings = bindings;
-
-    VkPhysicalDeviceFeatures2 pdf{};
-    pdf.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-    VkPhysicalDeviceSynchronization2Features pdf_sync2{};
-    pdf_sync2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES;
-    pdf_sync2.synchronization2 = VK_TRUE;
-    pdf.pNext = &pdf_sync2;
-
-    VpjShaderFileName shaderFileNames[1] = {};
-    shaderFileNames[0].pFilename = "shader.comp.spv";
-    shaderFileNames[0].stage = VK_SHADER_STAGE_COMPUTE_BIT;
+    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0, std::make_tuple(getVkPhysicalDeviceSynchronization2Features()));
 
     std::vector<uint32_t> ref_spirv{1, 2, 3, 4};
-    shaderFileNames[0].codeSize = ref_spirv.size() * sizeof(uint32_t);
-    shaderFileNames[0].pCode = ref_spirv.data();
+    auto [shaderFileNames, shaderFileNames_json] = getShaderFileNames(
+        {{VK_SHADER_STAGE_COMPUTE_BIT, "shader.comp.spv", ref_spirv.size() * sizeof(uint32_t), ref_spirv.data()}});
 
     const char* enabled_extensions[1] = {"VK_EXT_robustness2"};
 
     data.enabledExtensionCount = 1;
     data.ppEnabledExtensions = enabled_extensions;
     data.computePipelineState.pComputePipeline = &cp_ci;
-    data.computePipelineState.pDescriptorSetLayouts = &dsl_ci;
     data.computePipelineState.pPipelineLayout = &pl_ci;
     data.computePipelineState.immutableSamplerCount = 2;
     data.computePipelineState.ppImmutableSamplerNames = sampler_names;
@@ -3281,9 +703,55 @@ TEST_F(Gen, ComputePipelineJSONWithMD5) {
     data.computePipelineState.pDescriptorSetLayouts = &dsl_ci;
     data.computePipelineState.ppDescriptorSetLayoutNames = dsl_names;
     data.computePipelineState.pPhysicalDeviceFeatures = &pdf;
-    data.computePipelineState.shaderFileNameCount = 1;
-    data.computePipelineState.pShaderFileNames = shaderFileNames;
+    data.computePipelineState.shaderFileNameCount = (uint32_t)shaderFileNames.size();
+    data.computePipelineState.pShaderFileNames = shaderFileNames.data();
 
+    const std::string ref_json = R"({
+        "ComputePipelineState" :
+        {
+            "ComputePipeline" : )" +
+                                 cp_json +
+                                 R"(,
+            "DescriptorSetLayouts" :
+            [
+                {
+                    ")" + dsl_names[0] +
+                                 R"(" : )" + dsl_json + R"(
+                }
+            ],
+            "ImmutableSamplers" :
+            [
+                {
+                    ")" + sampler_names[0] +
+                                 R"(" : )" + immut_sampler_json + R"(
+                },
+                {
+                    ")" + sampler_names[1] +
+                                 R"(" : )" + ycbcr_sampler_json + R"(
+                }
+            ],
+            "PhysicalDeviceFeatures" : )" +
+                                 pdf_json + R"(,
+            "PipelineLayout" : )" +
+                                 pl_json +
+                                 R"(,
+            "ShaderFileNames" : )" +
+                                 shaderFileNames_json +
+                                 R"(,
+            "YcbcrSamplers" :
+            [
+                {
+                    ")" + ycbcr_names[0] +
+                                 R"(" : )" + ycbcr_json + R"(
+                }
+            ]
+        },
+        "EnabledExtensions" :
+        [
+            "VK_EXT_robustness2"
+        ],
+        "PipelineUUID" : [114, 122, 223, 248, 175, 155, 148, 173, 16, 102, 90, 164, 149, 132, 26, 51]
+    })";
     const char* result_json = nullptr;
 
     vpjSetMD5PipelineUUIDGeneration(generator_, true);
@@ -3296,626 +764,44 @@ TEST_F(Gen, ComputePipelineJSONWithMD5) {
 TEST_F(Gen, GraphicsPipelineJSONWithMD5) {
     TEST_DESCRIPTION("Tests generating pipeline JSON with MD5 UUID for a graphics pipeline");
 
-    const std::string ref_json{R"({
-    "EnabledExtensions" : 
-    [
-        "VK_EXT_robustness2"
-    ],
-    "GraphicsPipelineState" : 
-    {
-        "DescriptorSetLayouts" : 
-        [
-            {
-                "DescriptorSetLayout1" : 
-                {
-                    "bindingCount" : 3,
-                    "flags" : "VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT",
-                    "pBindings" : 
-                    [
-                        {
-                            "binding" : 0,
-                            "descriptorCount" : 1,
-                            "descriptorType" : "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
-                            "pImmutableSamplers" : [],
-                            "stageFlags" : "VK_SHADER_STAGE_COMPUTE_BIT"
-                        },
-                        {
-                            "binding" : 1,
-                            "descriptorCount" : 1,
-                            "descriptorType" : "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
-                            "pImmutableSamplers" : 
-                            [
-                                "ImmutableSampler1"
-                            ],
-                            "stageFlags" : "VK_SHADER_STAGE_FRAGMENT_BIT"
-                        },
-                        {
-                            "binding" : 2,
-                            "descriptorCount" : 1,
-                            "descriptorType" : "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
-                            "pImmutableSamplers" : 
-                            [
-                                "YcbcrSampler1"
-                            ],
-                            "stageFlags" : "VK_SHADER_STAGE_FRAGMENT_BIT"
-                        }
-                    ],
-                    "pNext" : 
-                    {
-                        "bindingCount" : 1,
-                        "pBindingFlags" : 
-                        [
-                            "VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT"
-                        ],
-                        "pNext" : "NULL",
-                        "sType" : "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO"
-                    },
-                    "sType" : "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO"
-                }
-            }
-        ],
-)"
-                               R"(
-        "GraphicsPipeline" : 
-        {
-            "basePipelineHandle" : "",
-            "basePipelineIndex" : 0,
-            "flags" : 0,
-            "layout" : "",
-            "pColorBlendState" : "NULL",
-            "pDepthStencilState" : "NULL",
-            "pDynamicState" : "NULL",
-            "pInputAssemblyState" : "NULL",
-            "pMultisampleState" : "NULL",
-            "pNext" : "NULL",
-            "pRasterizationState" : "NULL",
-            "pStages" : 
-            [
-                {
-                    "flags" : 0,
-                    "module" : "",
-                    "pName" : "main",
-                    "pNext" : "NULL",
-                    "pSpecializationInfo" : "NULL",
-                    "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                    "stage" : "VK_SHADER_STAGE_VERTEX_BIT"
-                },
-                {
-                    "flags" : 0,
-                    "module" : "",
-                    "pName" : "main",
-                    "pNext" : 
-                    {
-                        "pNext" : "NULL",
-                        "requiredSubgroupSize" : 64,
-                        "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO"
-                    },
-                    "pSpecializationInfo" : "NULL",
-                    "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                    "stage" : "VK_SHADER_STAGE_FRAGMENT_BIT"
-                }
-            ],
-            "pTessellationState" : "NULL",
-            "pVertexInputState" : "NULL",
-            "pViewportState" : "NULL",
-            "renderPass" : "",
-            "sType" : "VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO",
-            "stageCount" : 2,
-            "subpass" : 0
-        },
-)"
-                               R"(
-        "ImmutableSamplers" : 
-        [
-            {
-                "ImmutableSampler1" : 
-                {
-                    "addressModeU" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "addressModeV" : "VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT",
-                    "addressModeW" : "VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE",
-                    "anisotropyEnable" : "VK_FALSE",
-                    "borderColor" : "VK_BORDER_COLOR_FLOAT_CUSTOM_EXT",
-                    "compareEnable" : "VK_FALSE",
-                    "compareOp" : "VK_COMPARE_OP_NEVER",
-                    "flags" : 0,
-                    "magFilter" : "VK_FILTER_CUBIC_EXT",
-                    "maxAnisotropy" : 2.0,
-                    "maxLod" : 1000.0,
-                    "minFilter" : "VK_FILTER_NEAREST",
-                    "minLod" : 0.5,
-                    "mipLodBias" : 0.5,
-                    "mipmapMode" : "VK_SAMPLER_MIPMAP_MODE_LINEAR",
-                    "pNext" : 
-                    {
-                        "pNext" : "NULL",
-                        "reductionMode" : "VK_SAMPLER_REDUCTION_MODE_MAX",
-                        "sType" : "VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO"
-                    },
-                    "sType" : "VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO",
-                    "unnormalizedCoordinates" : "VK_TRUE"
-                }
-            },
-            {
-                "YcbcrSampler1" : 
-                {
-                    "addressModeU" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "addressModeV" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "addressModeW" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "anisotropyEnable" : "VK_FALSE",
-                    "borderColor" : "VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK",
-                    "compareEnable" : "VK_FALSE",
-                    "compareOp" : "VK_COMPARE_OP_NEVER",
-                    "flags" : 0,
-                    "magFilter" : "VK_FILTER_NEAREST",
-                    "maxAnisotropy" : 0.0,
-                    "maxLod" : 0.0,
-                    "minFilter" : "VK_FILTER_NEAREST",
-                    "minLod" : 0.0,
-                    "mipLodBias" : 0.0,
-                    "mipmapMode" : "VK_SAMPLER_MIPMAP_MODE_NEAREST",
-                    "pNext" : 
-                    {
-                        "conversion" : "YcbcrConversion1",
-                        "pNext" : "NULL",
-                        "sType" : "VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO"
-                    },
-                    "sType" : "VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO",
-                    "unnormalizedCoordinates" : "VK_FALSE"
-                }
-            }
-        ],
-)"
-                               R"(
-        "PhysicalDeviceFeatures" : 
-        {
-            "features" : 
-            {
-                "alphaToOne" : "VK_FALSE",
-                "depthBiasClamp" : "VK_FALSE",
-                "depthBounds" : "VK_FALSE",
-                "depthClamp" : "VK_FALSE",
-                "drawIndirectFirstInstance" : "VK_FALSE",
-                "dualSrcBlend" : "VK_FALSE",
-                "fillModeNonSolid" : "VK_FALSE",
-                "fragmentStoresAndAtomics" : "VK_FALSE",
-                "fullDrawIndexUint32" : "VK_FALSE",
-                "geometryShader" : "VK_FALSE",
-                "imageCubeArray" : "VK_FALSE",
-                "independentBlend" : "VK_FALSE",
-                "inheritedQueries" : "VK_FALSE",
-                "largePoints" : "VK_FALSE",
-                "logicOp" : "VK_FALSE",
-                "multiDrawIndirect" : "VK_FALSE",
-                "multiViewport" : "VK_FALSE",
-                "occlusionQueryPrecise" : "VK_FALSE",
-                "pipelineStatisticsQuery" : "VK_FALSE",
-                "robustBufferAccess" : "VK_TRUE",
-                "sampleRateShading" : "VK_FALSE",
-                "samplerAnisotropy" : "VK_FALSE",
-                "shaderClipDistance" : "VK_FALSE",
-                "shaderCullDistance" : "VK_FALSE",
-                "shaderFloat64" : "VK_FALSE",
-                "shaderImageGatherExtended" : "VK_FALSE",
-                "shaderInt16" : "VK_FALSE",
-                "shaderInt64" : "VK_FALSE",
-                "shaderResourceMinLod" : "VK_FALSE",
-                "shaderResourceResidency" : "VK_FALSE",
-                "shaderSampledImageArrayDynamicIndexing" : "VK_FALSE",
-                "shaderStorageBufferArrayDynamicIndexing" : "VK_FALSE",
-                "shaderStorageImageArrayDynamicIndexing" : "VK_FALSE",
-                "shaderStorageImageExtendedFormats" : "VK_FALSE",
-                "shaderStorageImageMultisample" : "VK_FALSE",
-                "shaderStorageImageReadWithoutFormat" : "VK_FALSE",
-                "shaderStorageImageWriteWithoutFormat" : "VK_FALSE",
-                "shaderTessellationAndGeometryPointSize" : "VK_FALSE",
-                "shaderUniformBufferArrayDynamicIndexing" : "VK_FALSE",
-                "sparseBinding" : "VK_FALSE",
-                "sparseResidency16Samples" : "VK_FALSE",
-                "sparseResidency2Samples" : "VK_FALSE",
-                "sparseResidency4Samples" : "VK_FALSE",
-                "sparseResidency8Samples" : "VK_FALSE",
-                "sparseResidencyAliased" : "VK_FALSE",
-                "sparseResidencyBuffer" : "VK_FALSE",
-                "sparseResidencyImage2D" : "VK_FALSE",
-                "sparseResidencyImage3D" : "VK_FALSE",
-                "tessellationShader" : "VK_FALSE",
-                "textureCompressionASTC_LDR" : "VK_FALSE",
-                "textureCompressionBC" : "VK_FALSE",
-                "textureCompressionETC2" : "VK_FALSE",
-                "variableMultisampleRate" : "VK_FALSE",
-                "vertexPipelineStoresAndAtomics" : "VK_FALSE",
-                "wideLines" : "VK_FALSE"
-            },
-            "pNext" : 
-            {
-                "pNext" : "NULL",
-                "sType" : "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES",
-                "synchronization2" : "VK_TRUE"
-            },
-            "sType" : "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2"
-        },
-)"
-                               R"(
-        "PipelineLayout" : 
-        {
-            "flags" : 0,
-            "pNext" : "NULL",
-            "pPushConstantRanges" : 
-            [
-                {
-                    "offset" : 0,
-                    "size" : 4,
-                    "stageFlags" : "VK_SHADER_STAGE_COMPUTE_BIT"
-                }
-            ],
-            "pSetLayouts" : 
-            [
-                "DescriptorSetLayout1"
-            ],
-            "pushConstantRangeCount" : 1,
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO",
-            "setLayoutCount" : 1
-        },
-)"
-                               R"(
-        "Renderpass" : 
-        {
-            "attachmentCount" : 2,
-            "dependencyCount" : 2,
-            "flags" : 0,
-            "pAttachments" : 
-            [
-                {
-                    "finalLayout" : "VK_IMAGE_LAYOUT_PRESENT_SRC_KHR",
-                    "flags" : 0,
-                    "format" : "VK_FORMAT_R8G8B8A8_UNORM",
-                    "initialLayout" : "VK_IMAGE_LAYOUT_UNDEFINED",
-                    "loadOp" : "VK_ATTACHMENT_LOAD_OP_CLEAR",
-                    "samples" : "VK_SAMPLE_COUNT_1_BIT",
-                    "stencilLoadOp" : "VK_ATTACHMENT_LOAD_OP_DONT_CARE",
-                    "stencilStoreOp" : "VK_ATTACHMENT_STORE_OP_DONT_CARE",
-                    "storeOp" : "VK_ATTACHMENT_STORE_OP_STORE"
-                },
-                {
-                    "finalLayout" : "VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL",
-                    "flags" : 0,
-                    "format" : "VK_FORMAT_D16_UNORM",
-                    "initialLayout" : "VK_IMAGE_LAYOUT_UNDEFINED",
-                    "loadOp" : "VK_ATTACHMENT_LOAD_OP_CLEAR",
-                    "samples" : "VK_SAMPLE_COUNT_1_BIT",
-                    "stencilLoadOp" : "VK_ATTACHMENT_LOAD_OP_DONT_CARE",
-                    "stencilStoreOp" : "VK_ATTACHMENT_STORE_OP_DONT_CARE",
-                    "storeOp" : "VK_ATTACHMENT_STORE_OP_DONT_CARE"
-                }
-            ],
-            "pDependencies" : 
-            [
-                {
-                    "dependencyFlags" : 0,
-                    "dstAccessMask" : "VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT",
-                    "dstStageMask" : "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
-                    "dstSubpass" : 0,
-                    "srcAccessMask" : "VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT",
-                    "srcStageMask" : "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
-                    "srcSubpass" : 4294967295
-                },
-                {
-                    "dependencyFlags" : 0,
-                    "dstAccessMask" : "VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT",
-                    "dstStageMask" : "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
-                    "dstSubpass" : 0,
-                    "srcAccessMask" : 0,
-                    "srcStageMask" : "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
-                    "srcSubpass" : 4294967295
-                }
-            ],
-            "pNext" : "NULL",
-            "pSubpasses" : 
-            [
-                {
-                    "colorAttachmentCount" : 1,
-                    "flags" : 0,
-                    "inputAttachmentCount" : 0,
-                    "pColorAttachments" : 
-                    [
-                        {
-                            "attachment" : 0,
-                            "layout" : "VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL"
-                        }
-                    ],
-                    "pDepthStencilAttachment" : 
-                    {
-                        "attachment" : 1,
-                        "layout" : "VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL"
-                    },
-                    "pInputAttachments" : "NULL",
-                    "pPreserveAttachments" : "NULL",
-                    "pResolveAttachments" : "NULL",
-                    "pipelineBindPoint" : "VK_PIPELINE_BIND_POINT_GRAPHICS",
-                    "preserveAttachmentCount" : 0
-                }
-            ],
-            "sType" : "VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO",
-            "subpassCount" : 1
-        },
-)"
-                               R"(
-        "ShaderFileNames" : 
-        [
-            {
-                "filename" : "shader.vert.spv",
-                "stage" : "VK_SHADER_STAGE_VERTEX_BIT"
-            },
-            {
-                "filename" : "shader.frag.spv",
-                "stage" : "VK_SHADER_STAGE_FRAGMENT_BIT"
-            }
-        ],
-        "YcbcrSamplers" : 
-        [
-            {
-                "YcbcrConversion1" : 
-                {
-                    "chromaFilter" : "VK_FILTER_CUBIC_EXT",
-                    "components" : 
-                    {
-                        "a" : "VK_COMPONENT_SWIZZLE_R",
-                        "b" : "VK_COMPONENT_SWIZZLE_G",
-                        "g" : "VK_COMPONENT_SWIZZLE_B",
-                        "r" : "VK_COMPONENT_SWIZZLE_A"
-                    },
-                    "forceExplicitReconstruction" : "VK_TRUE",
-                    "format" : "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16",
-                    "pNext" : "NULL",
-                    "sType" : "VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO",
-                    "xChromaOffset" : "VK_CHROMA_LOCATION_COSITED_EVEN",
-                    "yChromaOffset" : "VK_CHROMA_LOCATION_MIDPOINT",
-                    "ycbcrModel" : "VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020",
-                    "ycbcrRange" : "VK_SAMPLER_YCBCR_RANGE_ITU_NARROW"
-                }
-            }
-        ]
-    },
-    "PipelineUUID" :
-    [
-        49,
-        240,
-        91,
-        17,
-        162,
-        98,
-        76,
-        103,
-        145,
-        145,
-        146,
-        247,
-        163,
-        153,
-        172,
-        238
-    ]
-})"};
-
     VpjData data{};
 
-    VkRenderPassCreateInfo renderPass = {};
-    data.graphicsPipelineState.pRenderPass = &renderPass;
-    renderPass.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-    renderPass.pNext = nullptr;
-    renderPass.flags = 0;
-    renderPass.attachmentCount = 2;
-    VkAttachmentDescription attachments[2] = {{}, {}};
-    renderPass.pAttachments = attachments;
-    attachments[0].flags = 0;
-    attachments[0].format = VK_FORMAT_R8G8B8A8_UNORM;
-    attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
-    attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-    attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-    attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    attachments[0].finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-    attachments[1].flags = 0;
-    attachments[1].format = VK_FORMAT_D16_UNORM;
-    attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
-    attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-    attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    attachments[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    attachments[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    attachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-    renderPass.subpassCount = 1;
-    VkSubpassDescription subpasses[1] = {{}};
-    renderPass.pSubpasses = subpasses;
-    subpasses[0].flags = 0;
-    subpasses[0].pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-    subpasses[0].inputAttachmentCount = 0;
-    subpasses[0].pInputAttachments = nullptr;
-    subpasses[0].colorAttachmentCount = 1;
-    VkAttachmentReference colorAttachments[1] = {{}};
-    colorAttachments[0].attachment = 0;
-    colorAttachments[0].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-    subpasses[0].pColorAttachments = colorAttachments;
-    subpasses[0].pResolveAttachments = nullptr;
-    VkAttachmentReference depthStencilAttachment[1] = {{}};
-    depthStencilAttachment[0].attachment = 1;
-    depthStencilAttachment[0].layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-    subpasses[0].pDepthStencilAttachment = depthStencilAttachment;
-    subpasses[0].preserveAttachmentCount = 0;
-    subpasses[0].pPreserveAttachments = nullptr;
-    renderPass.dependencyCount = 2;
-    VkSubpassDependency dependencies[2] = {{}, {}};
-    dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
-    dependencies[0].dstSubpass = 0;
-    dependencies[0].srcStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
-    dependencies[0].dstStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
-    dependencies[0].srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-    dependencies[0].dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-    dependencies[0].dependencyFlags = 0;
-    dependencies[1].srcSubpass = VK_SUBPASS_EXTERNAL;
-    dependencies[1].dstSubpass = 0;
-    dependencies[1].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dependencies[1].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dependencies[1].srcAccessMask = 0;
-    dependencies[1].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
-    dependencies[1].dependencyFlags = 0;
-    renderPass.pDependencies = dependencies;
-
-    VkSamplerYcbcrConversionCreateInfo ycbcr_ci;
     const char* ycbcr_names[1] = {"YcbcrConversion1"};
-    ycbcr_ci.sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO;
-#ifdef VK_USE_PLATFORM_SCREEN_QNX
-    VkExternalFormatQNX ef_qnx{};
-    ef_qnx.sType = VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_QNX;
-    ef_qnx.pNext = nullptr;
-    ef_qnx.externalFormat = 10;
-    ycbcr_ci.pNext = &ef_qnx;
-#else
-    ycbcr_ci.pNext = nullptr;
-#endif  // VK_USE_PLATFORM_SCREEN_QNX
-    ycbcr_ci.format = VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16;
-    ycbcr_ci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020;
-    ycbcr_ci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_NARROW;
-    ycbcr_ci.components.r = VK_COMPONENT_SWIZZLE_A;
-    ycbcr_ci.components.g = VK_COMPONENT_SWIZZLE_B;
-    ycbcr_ci.components.b = VK_COMPONENT_SWIZZLE_G;
-    ycbcr_ci.components.a = VK_COMPONENT_SWIZZLE_R;
-    ycbcr_ci.xChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
-    ycbcr_ci.yChromaOffset = VK_CHROMA_LOCATION_MIDPOINT;
-    ycbcr_ci.chromaFilter = VK_FILTER_CUBIC_EXT;
-    ycbcr_ci.forceExplicitReconstruction = VK_TRUE;
+    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
+    auto ycbcr_conversion = VkSamplerYcbcrConversion(0);
 
-    VkSamplerCreateInfo sampler_ci[2] = {};
     const char* sampler_names[2] = {"ImmutableSampler1", "YcbcrSampler1"};
-
-    VkSamplerYcbcrConversionInfo ycbcrConversionInfo[1] = {};
-
-    ycbcrConversionInfo[0].sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO;
-    ycbcrConversionInfo[0].conversion = VkSamplerYcbcrConversion(0);
-
+    auto [immut_sampler_ci, immut_sampler_json] =
+        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerReductionModeCreateInfo(VK_SAMPLER_REDUCTION_MODE_MAX)));
+    auto [ycbcr_sampler_ci, ycbcr_sampler_json] =
+        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerYcbcrConversionInfo(ycbcr_conversion, ycbcr_names[0])));
+    VkSamplerCreateInfo sampler_ci[2] = {*immut_sampler_ci.ptr(), *ycbcr_sampler_ci.ptr()};
     VkSampler immutableSamplers[2] = {VkSampler(0), VkSampler(1)};
 
-    sampler_ci[0].sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    VkSamplerReductionModeCreateInfo srm_ci{};
-    srm_ci.sType = VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO;
-    srm_ci.pNext = nullptr;
-    srm_ci.reductionMode = VK_SAMPLER_REDUCTION_MODE_MAX;
-    sampler_ci[0].pNext = &srm_ci;
-    sampler_ci[0].flags = 0;
-    sampler_ci[0].magFilter = VK_FILTER_CUBIC_EXT;
-    sampler_ci[0].minFilter = VK_FILTER_NEAREST;
-    sampler_ci[0].mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-    sampler_ci[0].addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-    sampler_ci[0].addressModeV = VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
-    sampler_ci[0].addressModeW = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
-    sampler_ci[0].mipLodBias = 0.5f;
-    sampler_ci[0].anisotropyEnable = VK_FALSE;
-    sampler_ci[0].maxAnisotropy = 2.0f;
-    sampler_ci[0].compareEnable = VK_FALSE;
-    sampler_ci[0].compareOp = VK_COMPARE_OP_NEVER;
-    sampler_ci[0].minLod = 0.5f;
-    sampler_ci[0].maxLod = VK_LOD_CLAMP_NONE;
-    sampler_ci[0].borderColor = VK_BORDER_COLOR_FLOAT_CUSTOM_EXT;
-    sampler_ci[0].unnormalizedCoordinates = VK_TRUE;
-
-    sampler_ci[1].sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    sampler_ci[1].pNext = &ycbcrConversionInfo;
-
-    VkGraphicsPipelineCreateInfo gp_ci = {};
-    data.graphicsPipelineState.pGraphicsPipeline = &gp_ci;
-    gp_ci.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    gp_ci.pNext = nullptr;
-    gp_ci.flags = 0;
-    gp_ci.stageCount = 2;
-    VkPipelineShaderStageCreateInfo stages[2] = {{}, {}};
-    gp_ci.pStages = stages;
-    stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    stages[0].pNext = nullptr;
-    stages[0].flags = 0;
-    stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-    stages[0].module = reinterpret_cast<VkShaderModule>(38);
-    stages[0].pName = "main";
-    stages[0].pSpecializationInfo = nullptr;
-    stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    VkPipelineShaderStageRequiredSubgroupSizeCreateInfo pssrss_ci{};
-    pssrss_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO;
-    pssrss_ci.pNext = nullptr;
-    pssrss_ci.requiredSubgroupSize = 64;
-    stages[1].pNext = &pssrss_ci;
-    stages[1].flags = 0;
-    stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    stages[1].module = reinterpret_cast<VkShaderModule>(39);
-    stages[1].pName = "main";
-    stages[1].pSpecializationInfo = nullptr;
-
-    VkPipelineLayoutCreateInfo pl_ci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
-
-    VkDescriptorSetLayout setLayouts[3] = {VkDescriptorSetLayout(0)};
-    pl_ci.setLayoutCount = 1;
-    pl_ci.pSetLayouts = setLayouts;
-    VkPushConstantRange pushConstantRanges[1] = {};
-    pl_ci.pushConstantRangeCount = 1;
-    pushConstantRanges[0].size = 4;
-    pushConstantRanges[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    pl_ci.pPushConstantRanges = pushConstantRanges;
-
-    VkDescriptorSetLayoutCreateInfo dsl_ci{};
     const char* dsl_names[1] = {"DescriptorSetLayout1"};
+    auto [dsl_ci, dsl_json] =
+        getVkDescriptorSetLayoutCreateInfo(0,
+                                           {{1, VK_SHADER_STAGE_VERTEX_BIT},
+                                            {1, VK_SHADER_STAGE_FRAGMENT_BIT, immutableSamplers[0], sampler_names[0]},
+                                            {1, VK_SHADER_STAGE_FRAGMENT_BIT, immutableSamplers[1], sampler_names[1]}},
+                                           std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
 
-    dsl_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-    VkDescriptorSetLayoutBindingFlagsCreateInfo dslbf_ci{};
-    dslbf_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO;
-    dslbf_ci.pNext = nullptr;
-    dslbf_ci.bindingCount = 1;
-    VkDescriptorBindingFlags bindingFlags[1] = {};
-    bindingFlags[0] = VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT;
-    dslbf_ci.pBindingFlags = bindingFlags;
-    dsl_ci.pNext = &dslbf_ci;
-    dsl_ci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT;
+    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(0), dsl_names[0]}});
 
-    dsl_ci.bindingCount = 3;
-    VkDescriptorSetLayoutBinding bindings[3] = {};
+    auto [renderPass, renderPass_json] = getVkRenderPassCreateInfo(0);
 
-    bindings[0].binding = 0;
-    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    bindings[0].descriptorCount = 1;
-    bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    bindings[0].pImmutableSamplers = nullptr;
+    auto [gp_ci, gp_json] = getVkGraphicsPipelineCreateInfo(
+        0, {getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_VERTEX_BIT),
+            getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_FRAGMENT_BIT,
+                                               std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo()))});
 
-    bindings[1].binding = 1;
-    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    bindings[1].descriptorCount = 1;
-    bindings[1].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    bindings[1].pImmutableSamplers = &immutableSamplers[0];
-
-    bindings[2].binding = 2;
-    bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    bindings[2].descriptorCount = 1;
-    bindings[2].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    bindings[2].pImmutableSamplers = &immutableSamplers[1];
-
-    dsl_ci.pBindings = bindings;
-
-    VkPhysicalDeviceFeatures2 pdf{};
-    pdf.features.robustBufferAccess = VK_TRUE;
-    pdf.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-    VkPhysicalDeviceSynchronization2Features pdf_sync2{};
-    pdf_sync2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES;
-    pdf_sync2.synchronization2 = VK_TRUE;
-    pdf.pNext = &pdf_sync2;
-
-    VpjShaderFileName shaderFileNames[2] = {};
-    shaderFileNames[0].pFilename = "shader.vert.spv";
-    shaderFileNames[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-    shaderFileNames[1].pFilename = "shader.frag.spv";
-    shaderFileNames[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0, std::make_tuple(getVkPhysicalDeviceSynchronization2Features()));
 
     std::vector<uint32_t> ref_spirv{1, 2, 3, 4};
-    shaderFileNames[0].codeSize = ref_spirv.size() * sizeof(uint32_t);
-    shaderFileNames[0].pCode = ref_spirv.data();
-    shaderFileNames[1].codeSize = ref_spirv.size() * sizeof(uint32_t);
-    shaderFileNames[1].pCode = ref_spirv.data();
+    auto [shaderFileNames, shaderFileNames_json] = getShaderFileNames({
+        {VK_SHADER_STAGE_VERTEX_BIT, "shader.vert.spv", ref_spirv.size() * sizeof(uint32_t), ref_spirv.data()},
+        {VK_SHADER_STAGE_FRAGMENT_BIT, "shader.frag.spv", ref_spirv.size() * sizeof(uint32_t), ref_spirv.data()},
+    });
 
     const char* enabled_extensions[1] = {"VK_EXT_robustness2"};
 
@@ -3923,7 +809,6 @@ TEST_F(Gen, GraphicsPipelineJSONWithMD5) {
     data.ppEnabledExtensions = enabled_extensions;
     data.graphicsPipelineState.pGraphicsPipeline = &gp_ci;
     data.graphicsPipelineState.pRenderPass = &renderPass;
-    data.graphicsPipelineState.pDescriptorSetLayouts = &dsl_ci;
     data.graphicsPipelineState.pPipelineLayout = &pl_ci;
     data.graphicsPipelineState.immutableSamplerCount = 2;
     data.graphicsPipelineState.ppImmutableSamplerNames = sampler_names;
@@ -3935,9 +820,57 @@ TEST_F(Gen, GraphicsPipelineJSONWithMD5) {
     data.graphicsPipelineState.pDescriptorSetLayouts = &dsl_ci;
     data.graphicsPipelineState.ppDescriptorSetLayoutNames = dsl_names;
     data.graphicsPipelineState.pPhysicalDeviceFeatures = &pdf;
-    data.graphicsPipelineState.shaderFileNameCount = 2;
-    data.graphicsPipelineState.pShaderFileNames = shaderFileNames;
+    data.graphicsPipelineState.shaderFileNameCount = (uint32_t)shaderFileNames.size();
+    data.graphicsPipelineState.pShaderFileNames = shaderFileNames.data();
 
+    const std::string ref_json = R"({
+        "GraphicsPipelineState" :
+        {
+            "Renderpass": )" + renderPass_json +
+                                 R"(,
+            "GraphicsPipeline" : )" +
+                                 gp_json +
+                                 R"(,
+            "DescriptorSetLayouts" :
+            [
+                {
+                    ")" + dsl_names[0] +
+                                 R"(" : )" + dsl_json + R"(
+                }
+            ],
+            "ImmutableSamplers" :
+            [
+                {
+                    ")" + sampler_names[0] +
+                                 R"(" : )" + immut_sampler_json + R"(
+                },
+                {
+                    ")" + sampler_names[1] +
+                                 R"(" : )" + ycbcr_sampler_json + R"(
+                }
+            ],
+            "PhysicalDeviceFeatures" : )" +
+                                 pdf_json + R"(,
+            "PipelineLayout" : )" +
+                                 pl_json +
+                                 R"(,
+            "ShaderFileNames" : )" +
+                                 shaderFileNames_json +
+                                 R"(,
+            "YcbcrSamplers" :
+            [
+                {
+                    ")" + ycbcr_names[0] +
+                                 R"(" : )" + ycbcr_json + R"(
+                }
+            ]
+        },
+        "EnabledExtensions" :
+        [
+            "VK_EXT_robustness2"
+        ],
+        "PipelineUUID" : [204, 43, 222, 131, 254, 121, 127, 63, 143, 81, 2, 110, 227, 127, 168, 197]
+    })";
     const char* result_json = nullptr;
 
     vpjSetMD5PipelineUUIDGeneration(generator_, true);
@@ -4325,144 +1258,38 @@ TEST_F(Gen, ZeroShaderFilenamesCompute) {
 
     VpjData data{};
 
-    VkSamplerYcbcrConversionCreateInfo ycbcr_ci;
     const char* ycbcr_names[1] = {"YcbcrConversion1"};
-    ycbcr_ci.sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO;
-#ifdef VK_USE_PLATFORM_SCREEN_QNX
-    VkExternalFormatQNX ef_qnx{};
-    ef_qnx.sType = VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_QNX;
-    ef_qnx.pNext = nullptr;
-    ef_qnx.externalFormat = 10;
-    ycbcr_ci.pNext = &ef_qnx;
-#else
-    ycbcr_ci.pNext = nullptr;
-#endif  // VK_USE_PLATFORM_SCREEN_QNX
-    ycbcr_ci.format = VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16;
-    ycbcr_ci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020;
-    ycbcr_ci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_NARROW;
-    ycbcr_ci.components.r = VK_COMPONENT_SWIZZLE_A;
-    ycbcr_ci.components.g = VK_COMPONENT_SWIZZLE_B;
-    ycbcr_ci.components.b = VK_COMPONENT_SWIZZLE_G;
-    ycbcr_ci.components.a = VK_COMPONENT_SWIZZLE_R;
-    ycbcr_ci.xChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
-    ycbcr_ci.yChromaOffset = VK_CHROMA_LOCATION_MIDPOINT;
-    ycbcr_ci.chromaFilter = VK_FILTER_CUBIC_EXT;
-    ycbcr_ci.forceExplicitReconstruction = VK_TRUE;
+    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
+    auto ycbcr_conversion = VkSamplerYcbcrConversion(0);
 
-    VkSamplerCreateInfo sampler_ci[2] = {};
     const char* sampler_names[2] = {"ImmutableSampler1", "YcbcrSampler1"};
-
-    VkSamplerYcbcrConversionInfo ycbcrConversionInfo[1] = {};
-
-    ycbcrConversionInfo[0].sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO;
-    ycbcrConversionInfo[0].conversion = VkSamplerYcbcrConversion(0);
-
+    auto [immut_sampler_ci, immut_sampler_json] =
+        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerReductionModeCreateInfo(VK_SAMPLER_REDUCTION_MODE_MAX)));
+    auto [ycbcr_sampler_ci, ycbcr_sampler_json] =
+        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerYcbcrConversionInfo(ycbcr_conversion, ycbcr_names[0])));
+    VkSamplerCreateInfo sampler_ci[2] = {*immut_sampler_ci.ptr(), *ycbcr_sampler_ci.ptr()};
     VkSampler immutableSamplers[2] = {VkSampler(0), VkSampler(1)};
 
-    sampler_ci[0].sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    VkSamplerReductionModeCreateInfo srm_ci{};
-    srm_ci.sType = VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO;
-    srm_ci.pNext = nullptr;
-    srm_ci.reductionMode = VK_SAMPLER_REDUCTION_MODE_MAX;
-    sampler_ci[0].pNext = &srm_ci;
-    sampler_ci[0].flags = 0;
-    sampler_ci[0].magFilter = VK_FILTER_CUBIC_EXT;
-    sampler_ci[0].minFilter = VK_FILTER_NEAREST;
-    sampler_ci[0].mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-    sampler_ci[0].addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-    sampler_ci[0].addressModeV = VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
-    sampler_ci[0].addressModeW = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
-    sampler_ci[0].mipLodBias = 0.5f;
-    sampler_ci[0].anisotropyEnable = VK_FALSE;
-    sampler_ci[0].maxAnisotropy = 2.0f;
-    sampler_ci[0].compareEnable = VK_FALSE;
-    sampler_ci[0].compareOp = VK_COMPARE_OP_NEVER;
-    sampler_ci[0].minLod = 0.5f;
-    sampler_ci[0].maxLod = VK_LOD_CLAMP_NONE;
-    sampler_ci[0].borderColor = VK_BORDER_COLOR_FLOAT_CUSTOM_EXT;
-    sampler_ci[0].unnormalizedCoordinates = VK_TRUE;
-
-    sampler_ci[1].sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    sampler_ci[1].pNext = &ycbcrConversionInfo;
-
-    VkComputePipelineCreateInfo cp_ci{};
-    cp_ci.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
-    cp_ci.pNext = nullptr;
-    cp_ci.flags = 0;
-    cp_ci.stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-
-    VkPipelineLayoutCreateInfo pl_ci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
-
-    VkDescriptorSetLayout setLayouts[3] = {VkDescriptorSetLayout(0)};
-    pl_ci.setLayoutCount = 1;
-    pl_ci.pSetLayouts = setLayouts;
-    VkPushConstantRange pushConstantRanges[1] = {};
-    pl_ci.pushConstantRangeCount = 1;
-    pushConstantRanges[0].size = 4;
-    pushConstantRanges[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    pl_ci.pPushConstantRanges = pushConstantRanges;
-
-    VkPipelineShaderStageRequiredSubgroupSizeCreateInfo pssrss_ci{};
-    pssrss_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO;
-    pssrss_ci.pNext = nullptr;
-    pssrss_ci.requiredSubgroupSize = 64;
-    cp_ci.stage.pNext = &pssrss_ci;
-
-    cp_ci.stage.flags = VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT;
-    cp_ci.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    cp_ci.stage.pName = "main";
-
-    VkDescriptorSetLayoutCreateInfo dsl_ci{};
     const char* dsl_names[1] = {"DescriptorSetLayout1"};
+    auto [dsl_ci, dsl_json] =
+        getVkDescriptorSetLayoutCreateInfo(0,
+                                           {{1, VK_SHADER_STAGE_COMPUTE_BIT},
+                                            {1, VK_SHADER_STAGE_COMPUTE_BIT, immutableSamplers[0], sampler_names[0]},
+                                            {1, VK_SHADER_STAGE_COMPUTE_BIT, immutableSamplers[1], sampler_names[1]}},
+                                           std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
 
-    dsl_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-    VkDescriptorSetLayoutBindingFlagsCreateInfo dslbf_ci{};
-    dslbf_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO;
-    dslbf_ci.pNext = nullptr;
-    dslbf_ci.bindingCount = 1;
-    VkDescriptorBindingFlags bindingFlags[1] = {};
-    bindingFlags[0] = VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT;
-    dslbf_ci.pBindingFlags = bindingFlags;
-    dsl_ci.pNext = &dslbf_ci;
-    dsl_ci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT;
+    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(0), dsl_names[0]}});
 
-    dsl_ci.bindingCount = 3;
-    VkDescriptorSetLayoutBinding bindings[3] = {};
+    auto [cp_ci, cp_json] = getVkComputePipelineCreateInfo(getVkPipelineShaderStageCreateInfo(
+        0, VK_SHADER_STAGE_COMPUTE_BIT, std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo())));
 
-    bindings[0].binding = 0;
-    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    bindings[0].descriptorCount = 1;
-    bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    bindings[0].pImmutableSamplers = nullptr;
-
-    bindings[1].binding = 1;
-    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    bindings[1].descriptorCount = 1;
-    bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    bindings[1].pImmutableSamplers = &immutableSamplers[0];
-
-    bindings[2].binding = 2;
-    bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    bindings[2].descriptorCount = 1;
-    bindings[2].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    bindings[2].pImmutableSamplers = &immutableSamplers[1];
-
-    dsl_ci.pBindings = bindings;
-
-    VkPhysicalDeviceFeatures2 pdf{};
-    pdf.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-    pdf.features.robustBufferAccess = VK_TRUE;
-    VkPhysicalDeviceSynchronization2Features pdf_sync2{};
-    pdf_sync2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES;
-    pdf_sync2.synchronization2 = VK_TRUE;
-    pdf.pNext = &pdf_sync2;
+    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0, std::make_tuple(getVkPhysicalDeviceSynchronization2Features()));
 
     const char* enabled_extensions[1] = {"VK_EXT_robustness2"};
 
     data.enabledExtensionCount = 1;
     data.ppEnabledExtensions = enabled_extensions;
     data.computePipelineState.pComputePipeline = &cp_ci;
-    data.computePipelineState.pDescriptorSetLayouts = &dsl_ci;
     data.computePipelineState.pPipelineLayout = &pl_ci;
     data.computePipelineState.immutableSamplerCount = 2;
     data.computePipelineState.ppImmutableSamplerNames = sampler_names;
@@ -4496,211 +1323,36 @@ TEST_F(Gen, ZeroShaderFilenamesGraphics) {
 
     VpjData data{};
 
-    VkRenderPassCreateInfo renderPass = {};
-    data.graphicsPipelineState.pRenderPass = &renderPass;
-    renderPass.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-    renderPass.pNext = nullptr;
-    renderPass.flags = 0;
-    renderPass.attachmentCount = 2;
-    VkAttachmentDescription attachments[2] = {{}, {}};
-    renderPass.pAttachments = attachments;
-    attachments[0].flags = 0;
-    attachments[0].format = VK_FORMAT_R8G8B8A8_UNORM;
-    attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
-    attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-    attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-    attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    attachments[0].finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-    attachments[1].flags = 0;
-    attachments[1].format = VK_FORMAT_D16_UNORM;
-    attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
-    attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-    attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    attachments[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    attachments[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    attachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-    renderPass.subpassCount = 1;
-    VkSubpassDescription subpasses[1] = {{}};
-    renderPass.pSubpasses = subpasses;
-    subpasses[0].flags = 0;
-    subpasses[0].pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-    subpasses[0].inputAttachmentCount = 0;
-    subpasses[0].pInputAttachments = nullptr;
-    subpasses[0].colorAttachmentCount = 1;
-    VkAttachmentReference colorAttachments[1] = {{}};
-    colorAttachments[0].attachment = 0;
-    colorAttachments[0].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-    subpasses[0].pColorAttachments = colorAttachments;
-    subpasses[0].pResolveAttachments = nullptr;
-    VkAttachmentReference depthStencilAttachment[1] = {{}};
-    depthStencilAttachment[0].attachment = 1;
-    depthStencilAttachment[0].layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-    subpasses[0].pDepthStencilAttachment = depthStencilAttachment;
-    subpasses[0].preserveAttachmentCount = 0;
-    subpasses[0].pPreserveAttachments = nullptr;
-    renderPass.dependencyCount = 2;
-    VkSubpassDependency dependencies[2] = {{}, {}};
-    dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
-    dependencies[0].dstSubpass = 0;
-    dependencies[0].srcStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
-    dependencies[0].dstStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
-    dependencies[0].srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-    dependencies[0].dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-    dependencies[0].dependencyFlags = 0;
-    dependencies[1].srcSubpass = VK_SUBPASS_EXTERNAL;
-    dependencies[1].dstSubpass = 0;
-    dependencies[1].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dependencies[1].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dependencies[1].srcAccessMask = 0;
-    dependencies[1].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
-    dependencies[1].dependencyFlags = 0;
-    renderPass.pDependencies = dependencies;
-
-    VkSamplerYcbcrConversionCreateInfo ycbcr_ci;
     const char* ycbcr_names[1] = {"YcbcrConversion1"};
-    ycbcr_ci.sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO;
-#ifdef VK_USE_PLATFORM_SCREEN_QNX
-    VkExternalFormatQNX ef_qnx{};
-    ef_qnx.sType = VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_QNX;
-    ef_qnx.pNext = nullptr;
-    ef_qnx.externalFormat = 10;
-    ycbcr_ci.pNext = &ef_qnx;
-#else
-    ycbcr_ci.pNext = nullptr;
-#endif  // VK_USE_PLATFORM_SCREEN_QNX
-    ycbcr_ci.format = VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16;
-    ycbcr_ci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020;
-    ycbcr_ci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_NARROW;
-    ycbcr_ci.components.r = VK_COMPONENT_SWIZZLE_A;
-    ycbcr_ci.components.g = VK_COMPONENT_SWIZZLE_B;
-    ycbcr_ci.components.b = VK_COMPONENT_SWIZZLE_G;
-    ycbcr_ci.components.a = VK_COMPONENT_SWIZZLE_R;
-    ycbcr_ci.xChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
-    ycbcr_ci.yChromaOffset = VK_CHROMA_LOCATION_MIDPOINT;
-    ycbcr_ci.chromaFilter = VK_FILTER_CUBIC_EXT;
-    ycbcr_ci.forceExplicitReconstruction = VK_TRUE;
+    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
+    auto ycbcr_conversion = VkSamplerYcbcrConversion(0);
 
-    VkSamplerCreateInfo sampler_ci[2] = {};
     const char* sampler_names[2] = {"ImmutableSampler1", "YcbcrSampler1"};
-
-    VkSamplerYcbcrConversionInfo ycbcrConversionInfo[1] = {};
-
-    ycbcrConversionInfo[0].sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO;
-    ycbcrConversionInfo[0].conversion = VkSamplerYcbcrConversion(0);
-
+    auto [immut_sampler_ci, immut_sampler_json] =
+        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerReductionModeCreateInfo(VK_SAMPLER_REDUCTION_MODE_MAX)));
+    auto [ycbcr_sampler_ci, ycbcr_sampler_json] =
+        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerYcbcrConversionInfo(ycbcr_conversion, ycbcr_names[0])));
+    VkSamplerCreateInfo sampler_ci[2] = {*immut_sampler_ci.ptr(), *ycbcr_sampler_ci.ptr()};
     VkSampler immutableSamplers[2] = {VkSampler(0), VkSampler(1)};
 
-    sampler_ci[0].sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    VkSamplerReductionModeCreateInfo srm_ci{};
-    srm_ci.sType = VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO;
-    srm_ci.pNext = nullptr;
-    srm_ci.reductionMode = VK_SAMPLER_REDUCTION_MODE_MAX;
-    sampler_ci[0].pNext = &srm_ci;
-    sampler_ci[0].flags = 0;
-    sampler_ci[0].magFilter = VK_FILTER_CUBIC_EXT;
-    sampler_ci[0].minFilter = VK_FILTER_NEAREST;
-    sampler_ci[0].mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-    sampler_ci[0].addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-    sampler_ci[0].addressModeV = VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
-    sampler_ci[0].addressModeW = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
-    sampler_ci[0].mipLodBias = 0.5f;
-    sampler_ci[0].anisotropyEnable = VK_FALSE;
-    sampler_ci[0].maxAnisotropy = 2.0f;
-    sampler_ci[0].compareEnable = VK_FALSE;
-    sampler_ci[0].compareOp = VK_COMPARE_OP_NEVER;
-    sampler_ci[0].minLod = 0.5f;
-    sampler_ci[0].maxLod = VK_LOD_CLAMP_NONE;
-    sampler_ci[0].borderColor = VK_BORDER_COLOR_FLOAT_CUSTOM_EXT;
-    sampler_ci[0].unnormalizedCoordinates = VK_TRUE;
-
-    sampler_ci[1].sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    sampler_ci[1].pNext = &ycbcrConversionInfo;
-
-    VkGraphicsPipelineCreateInfo gp_ci = {};
-    data.graphicsPipelineState.pGraphicsPipeline = &gp_ci;
-    gp_ci.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    gp_ci.pNext = nullptr;
-    gp_ci.flags = 0;
-    gp_ci.stageCount = 2;
-    VkPipelineShaderStageCreateInfo stages[2] = {{}, {}};
-    gp_ci.pStages = stages;
-    stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    stages[0].pNext = nullptr;
-    stages[0].flags = 0;
-    stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-    stages[0].module = reinterpret_cast<VkShaderModule>(38);
-    stages[0].pName = "main";
-    stages[0].pSpecializationInfo = nullptr;
-    stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    VkPipelineShaderStageRequiredSubgroupSizeCreateInfo pssrss_ci{};
-    pssrss_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO;
-    pssrss_ci.pNext = nullptr;
-    pssrss_ci.requiredSubgroupSize = 64;
-    stages[1].pNext = &pssrss_ci;
-    stages[1].flags = 0;
-    stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    stages[1].module = reinterpret_cast<VkShaderModule>(39);
-    stages[1].pName = "main";
-    stages[1].pSpecializationInfo = nullptr;
-
-    VkPipelineLayoutCreateInfo pl_ci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
-
-    VkDescriptorSetLayout setLayouts[3] = {VkDescriptorSetLayout(0)};
-    pl_ci.setLayoutCount = 1;
-    pl_ci.pSetLayouts = setLayouts;
-    VkPushConstantRange pushConstantRanges[1] = {};
-    pl_ci.pushConstantRangeCount = 1;
-    pushConstantRanges[0].size = 4;
-    pushConstantRanges[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    pl_ci.pPushConstantRanges = pushConstantRanges;
-
-    VkDescriptorSetLayoutCreateInfo dsl_ci{};
     const char* dsl_names[1] = {"DescriptorSetLayout1"};
+    auto [dsl_ci, dsl_json] =
+        getVkDescriptorSetLayoutCreateInfo(0,
+                                           {{1, VK_SHADER_STAGE_VERTEX_BIT},
+                                            {1, VK_SHADER_STAGE_FRAGMENT_BIT, immutableSamplers[0], sampler_names[0]},
+                                            {1, VK_SHADER_STAGE_FRAGMENT_BIT, immutableSamplers[1], sampler_names[1]}},
+                                           std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
 
-    dsl_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-    VkDescriptorSetLayoutBindingFlagsCreateInfo dslbf_ci{};
-    dslbf_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO;
-    dslbf_ci.pNext = nullptr;
-    dslbf_ci.bindingCount = 1;
-    VkDescriptorBindingFlags bindingFlags[1] = {};
-    bindingFlags[0] = VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT;
-    dslbf_ci.pBindingFlags = bindingFlags;
-    dsl_ci.pNext = &dslbf_ci;
-    dsl_ci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT;
+    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(0), dsl_names[0]}});
 
-    dsl_ci.bindingCount = 3;
-    VkDescriptorSetLayoutBinding bindings[3] = {};
+    auto [renderPass, renderPass_json] = getVkRenderPassCreateInfo(0);
 
-    bindings[0].binding = 0;
-    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    bindings[0].descriptorCount = 1;
-    bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    bindings[0].pImmutableSamplers = nullptr;
+    auto [gp_ci, gp_json] = getVkGraphicsPipelineCreateInfo(
+        0, {getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_VERTEX_BIT),
+            getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_FRAGMENT_BIT,
+                                               std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo()))});
 
-    bindings[1].binding = 1;
-    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    bindings[1].descriptorCount = 1;
-    bindings[1].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    bindings[1].pImmutableSamplers = &immutableSamplers[0];
-
-    bindings[2].binding = 2;
-    bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    bindings[2].descriptorCount = 1;
-    bindings[2].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    bindings[2].pImmutableSamplers = &immutableSamplers[1];
-
-    dsl_ci.pBindings = bindings;
-
-    VkPhysicalDeviceFeatures2 pdf{};
-    pdf.features.robustBufferAccess = VK_TRUE;
-    pdf.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-    VkPhysicalDeviceSynchronization2Features pdf_sync2{};
-    pdf_sync2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES;
-    pdf_sync2.synchronization2 = VK_TRUE;
-    pdf.pNext = &pdf_sync2;
+    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0, std::make_tuple(getVkPhysicalDeviceSynchronization2Features()));
 
     const char* enabled_extensions[1] = {"VK_EXT_robustness2"};
 
@@ -4708,7 +1360,6 @@ TEST_F(Gen, ZeroShaderFilenamesGraphics) {
     data.ppEnabledExtensions = enabled_extensions;
     data.graphicsPipelineState.pGraphicsPipeline = &gp_ci;
     data.graphicsPipelineState.pRenderPass = &renderPass;
-    data.graphicsPipelineState.pDescriptorSetLayouts = &dsl_ci;
     data.graphicsPipelineState.pPipelineLayout = &pl_ci;
     data.graphicsPipelineState.immutableSamplerCount = 2;
     data.graphicsPipelineState.ppImmutableSamplerNames = sampler_names;

--- a/tests/pcjson/pcjson_test_parse.cpp
+++ b/tests/pcjson/pcjson_test_parse.cpp
@@ -287,123 +287,13 @@ TEST_F(Parse, VkShaderModuleCreateInfo) {
 TEST_F(Parse, VkDeviceObjectReservationCreateInfo) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex object reservation create info JSON");
 
-    VkDeviceObjectReservationCreateInfo dor_ci;
-    std::string json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_DEVICE_OBJECT_RESERVATION_CREATE_INFO",
-        "pNext": "NULL",
-        "pipelineCacheCreateInfoCount": 1,
-        "pPipelineCacheCreateInfos": [
-            {
-                "sType": "VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO",
-                "pNext": "NULL",
-                "flags": "VK_PIPELINE_CACHE_CREATE_READ_ONLY_BIT | VK_PIPELINE_CACHE_CREATE_USE_APPLICATION_STORAGE_BIT",
-                "initialDataSize": 3,
-                "pInitialData": "abcd"
-            }
-        ],
-        "pipelinePoolSizeCount": 1,
-        "pPipelinePoolSizes": [
-            {
-                "sType": "VK_STRUCTURE_TYPE_PIPELINE_POOL_SIZE",
-                "pNext": "NULL",
-                "poolEntryCount": 1,
-                "poolEntrySize": 1048576
-            }
-        ],
-        "semaphoreRequestCount": 0,
-        "commandBufferRequestCount": 1,
-        "fenceRequestCount": 1,
-        "deviceMemoryRequestCount": 2,
-        "bufferRequestCount": 2,
-        "imageRequestCount": 0,
-        "eventRequestCount": 0,
-        "queryPoolRequestCount": 0,
-        "bufferViewRequestCount": 0,
-        "imageViewRequestCount": 0,
-        "layeredImageViewRequestCount": 0,
-        "pipelineCacheRequestCount": 1,
-        "pipelineLayoutRequestCount": 1,
-        "renderPassRequestCount": 1,
-        "graphicsPipelineRequestCount": 0,
-        "computePipelineRequestCount": 1,
-        "descriptorSetLayoutRequestCount": 1,
-        "samplerRequestCount": 0,
-        "descriptorPoolRequestCount": 1,
-        "descriptorSetRequestCount": 1,
-        "framebufferRequestCount": 0,
-        "commandPoolRequestCount": 2,
-        "samplerYcbcrConversionRequestCount": 0,
-        "surfaceRequestCount": 0,
-        "swapchainRequestCount": 1,
-        "displayModeRequestCount": 0,
-        "subpassDescriptionRequestCount": 1,
-        "attachmentDescriptionRequestCount": 2,
-        "descriptorSetLayoutBindingRequestCount": 2,
-        "descriptorSetLayoutBindingLimit": 2,
-        "maxImageViewMipLevels": 1,
-        "maxImageViewArrayLayers": 1,
-        "maxLayeredImageViewMipLevels": 0,
-        "maxOcclusionQueriesPerPool": 0,
-        "maxPipelineStatisticsQueriesPerPool": 0,
-        "maxTimestampQueriesPerPool": 0,
-        "maxImmutableSamplersPerDescriptorSetLayout": 0
-    })"};
+    for (auto seed : {0}) {
+        auto [ref_ci, json_in] = getVkDeviceObjectReservationCreateInfo(seed);
 
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &dor_ci, &msg_));
-
-    EXPECT_EQ(dor_ci.sType, VK_STRUCTURE_TYPE_DEVICE_OBJECT_RESERVATION_CREATE_INFO);
-    EXPECT_EQ(dor_ci.pNext, nullptr);
-    EXPECT_EQ(dor_ci.pipelineCacheCreateInfoCount, 1);
-    EXPECT_EQ(dor_ci.pPipelineCacheCreateInfos[0].sType, VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO);
-    EXPECT_EQ(dor_ci.pPipelineCacheCreateInfos[0].pNext, nullptr);
-    EXPECT_EQ(dor_ci.pPipelineCacheCreateInfos[0].flags,
-              VK_PIPELINE_CACHE_CREATE_READ_ONLY_BIT | VK_PIPELINE_CACHE_CREATE_USE_APPLICATION_STORAGE_BIT);
-    EXPECT_EQ(dor_ci.pPipelineCacheCreateInfos[0].initialDataSize, 3);
-    EXPECT_EQ(static_cast<const unsigned char*>(dor_ci.pPipelineCacheCreateInfos[0].pInitialData)[0], 0b01101001);
-    EXPECT_EQ(static_cast<const unsigned char*>(dor_ci.pPipelineCacheCreateInfos[0].pInitialData)[1], 0b10110111);
-    EXPECT_EQ(static_cast<const unsigned char*>(dor_ci.pPipelineCacheCreateInfos[0].pInitialData)[2], 0b00011101);
-    EXPECT_EQ(dor_ci.pipelinePoolSizeCount, 1);
-    EXPECT_EQ(dor_ci.pPipelinePoolSizes[0].sType, VK_STRUCTURE_TYPE_PIPELINE_POOL_SIZE);
-    EXPECT_EQ(dor_ci.pPipelinePoolSizes[0].pNext, nullptr);
-    EXPECT_EQ(dor_ci.pPipelinePoolSizes[0].poolEntryCount, 1);
-    EXPECT_EQ(dor_ci.pPipelinePoolSizes[0].poolEntrySize, 1048576);
-    EXPECT_EQ(dor_ci.semaphoreRequestCount, 0);
-    EXPECT_EQ(dor_ci.commandBufferRequestCount, 1);
-    EXPECT_EQ(dor_ci.fenceRequestCount, 1);
-    EXPECT_EQ(dor_ci.deviceMemoryRequestCount, 2);
-    EXPECT_EQ(dor_ci.bufferRequestCount, 2);
-    EXPECT_EQ(dor_ci.imageRequestCount, 0);
-    EXPECT_EQ(dor_ci.eventRequestCount, 0);
-    EXPECT_EQ(dor_ci.queryPoolRequestCount, 0);
-    EXPECT_EQ(dor_ci.bufferViewRequestCount, 0);
-    EXPECT_EQ(dor_ci.imageViewRequestCount, 0);
-    EXPECT_EQ(dor_ci.layeredImageViewRequestCount, 0);
-    EXPECT_EQ(dor_ci.pipelineCacheRequestCount, 1);
-    EXPECT_EQ(dor_ci.pipelineLayoutRequestCount, 1);
-    EXPECT_EQ(dor_ci.renderPassRequestCount, 1);
-    EXPECT_EQ(dor_ci.graphicsPipelineRequestCount, 0);
-    EXPECT_EQ(dor_ci.computePipelineRequestCount, 1);
-    EXPECT_EQ(dor_ci.descriptorSetLayoutRequestCount, 1);
-    EXPECT_EQ(dor_ci.samplerRequestCount, 0);
-    EXPECT_EQ(dor_ci.descriptorPoolRequestCount, 1);
-    EXPECT_EQ(dor_ci.descriptorSetRequestCount, 1);
-    EXPECT_EQ(dor_ci.framebufferRequestCount, 0);
-    EXPECT_EQ(dor_ci.commandPoolRequestCount, 2);
-    EXPECT_EQ(dor_ci.samplerYcbcrConversionRequestCount, 0);
-    EXPECT_EQ(dor_ci.surfaceRequestCount, 0);
-    EXPECT_EQ(dor_ci.swapchainRequestCount, 1);
-    EXPECT_EQ(dor_ci.displayModeRequestCount, 0);
-    EXPECT_EQ(dor_ci.subpassDescriptionRequestCount, 1);
-    EXPECT_EQ(dor_ci.attachmentDescriptionRequestCount, 2);
-    EXPECT_EQ(dor_ci.descriptorSetLayoutBindingRequestCount, 2);
-    EXPECT_EQ(dor_ci.descriptorSetLayoutBindingLimit, 2);
-    EXPECT_EQ(dor_ci.maxImageViewMipLevels, 1);
-    EXPECT_EQ(dor_ci.maxImageViewArrayLayers, 1);
-    EXPECT_EQ(dor_ci.maxLayeredImageViewMipLevels, 0);
-    EXPECT_EQ(dor_ci.maxOcclusionQueriesPerPool, 0);
-    EXPECT_EQ(dor_ci.maxPipelineStatisticsQueriesPerPool, 0);
-    EXPECT_EQ(dor_ci.maxTimestampQueriesPerPool, 0);
-    EXPECT_EQ(dor_ci.maxImmutableSamplersPerDescriptorSetLayout, 0);
+        VkDeviceObjectReservationCreateInfo res_ci{};
+        CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json_in.c_str(), &res_ci, &msg_));
+        CompareStruct(ref_ci, res_ci);
+    }
 }
 
 TEST_F(Parse, VkPipelineOfflineCreateInfo) {

--- a/tests/pcjson/pcjson_test_parse.cpp
+++ b/tests/pcjson/pcjson_test_parse.cpp
@@ -19,6 +19,7 @@
 #include <math.h>
 
 #include "json_validator.h"
+#include "json_struct_helpers.h"
 
 class Parse : public testing::Test {
   public:
@@ -32,11 +33,6 @@ class Parse : public testing::Test {
         EXPECT_TRUE(success);
         if (msg_ && strlen(msg_)) {
             FAIL() << msg_;
-        }
-    }
-    void EXPECT_UUIDEQ(uint8_t* it1, uint8_t* it2) {
-        for (unsigned int i = 0; i < VK_UUID_SIZE; ++i) {
-            EXPECT_EQ(it1[i], it2[i]);
         }
     }
 
@@ -169,1298 +165,108 @@ TEST_F(Parse, BasicTypesVkBool32) {
 TEST_F(Parse, VkPhysicalDeviceFeatures2) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex physical device features 2 JSON");
 
-    VkPhysicalDeviceFeatures2 pdf;
-    std::string json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2",
-        "pNext": {
-            "sType" : "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES",
-            "pNext": "NULL",
-            "synchronization2" : "VK_TRUE"
-        },
-        "features": {
-            "robustBufferAccess": "VK_FALSE",
-            "fullDrawIndexUint32" : "VK_TRUE",
-            "imageCubeArray" : "VK_FALSE",
-            "independentBlend" : "VK_TRUE",
-            "geometryShader" : "VK_FALSE",
-            "tessellationShader" : "VK_TRUE",
-            "sampleRateShading" : "VK_FALSE",
-            "dualSrcBlend" : "VK_TRUE",
-            "logicOp" : "VK_FALSE",
-            "multiDrawIndirect" : "VK_TRUE",
-            "drawIndirectFirstInstance" : "VK_FALSE",
-            "depthClamp" : "VK_FALSE",
-            "depthBiasClamp" : "VK_TRUE",
-            "fillModeNonSolid" : "VK_FALSE",
-            "depthBounds" : "VK_TRUE",
-            "wideLines" : "VK_FALSE",
-            "largePoints" : "VK_TRUE",
-            "alphaToOne" : "VK_FALSE",
-            "multiViewport" : "VK_TRUE",
-            "samplerAnisotropy" : "VK_FALSE",
-            "textureCompressionETC2" : "VK_TRUE",
-            "textureCompressionASTC_LDR" : "VK_FALSE",
-            "textureCompressionBC" : "VK_TRUE",
-            "occlusionQueryPrecise" : "VK_FALSE",
-            "pipelineStatisticsQuery" : "VK_TRUE",
-            "vertexPipelineStoresAndAtomics" : "VK_FALSE",
-            "fragmentStoresAndAtomics" : "VK_FALSE",
-            "shaderTessellationAndGeometryPointSize" : "VK_TRUE",
-            "shaderImageGatherExtended" : "VK_FALSE",
-            "shaderStorageImageExtendedFormats" : "VK_TRUE",
-            "shaderStorageImageMultisample" : "VK_FALSE",
-            "shaderStorageImageReadWithoutFormat" : "VK_TRUE",
-            "shaderStorageImageWriteWithoutFormat" : "VK_FALSE",
-            "shaderUniformBufferArrayDynamicIndexing" : "VK_TRUE",
-            "shaderSampledImageArrayDynamicIndexing" : "VK_FALSE",
-            "shaderStorageBufferArrayDynamicIndexing" : "VK_TRUE",
-            "shaderStorageImageArrayDynamicIndexing" : "VK_FALSE",
-            "shaderClipDistance" : "VK_TRUE",
-            "shaderCullDistance" : "VK_FALSE",
-            "shaderFloat64" : "VK_TRUE",
-            "shaderInt64" : "VK_FALSE",
-            "shaderInt16" : "VK_TRUE",
-            "shaderResourceResidency" : "VK_FALSE",
-            "shaderResourceMinLod" : "VK_TRUE",
-            "sparseBinding" : "VK_FALSE",
-            "sparseResidencyBuffer" : "VK_TRUE",
-            "sparseResidencyImage2D" : "VK_FALSE",
-            "sparseResidencyImage3D" : "VK_TRUE",
-            "sparseResidency2Samples" : "VK_FALSE",
-            "sparseResidency4Samples" : "VK_TRUE",
-            "sparseResidency8Samples" : "VK_FALSE",
-            "sparseResidency16Samples" : "VK_TRUE",
-            "sparseResidencyAliased" : "VK_FALSE",
-            "variableMultisampleRate" : "VK_TRUE",
-            "inheritedQueries" : "VK_FALSE"
-        }
-    })"};
+    VkPhysicalDeviceFeatures2 pdf{};
+    auto [ref_pdf, json] = getVkPhysicalDeviceFeatures2(
+        0, std::make_tuple(getVkPhysicalDeviceVulkan11Features(), getVkPhysicalDeviceScalarBlockLayoutFeatures()));
 
     CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &pdf, &msg_));
-    const auto& pdfsync2 = *reinterpret_cast<const VkPhysicalDeviceSynchronization2Features*>(pdf.pNext);
-
-    EXPECT_EQ(pdf.sType, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2);
-    EXPECT_EQ(pdfsync2.sType, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES);
-    EXPECT_EQ(pdfsync2.pNext, nullptr);
-    EXPECT_EQ(pdfsync2.synchronization2, VK_TRUE);
-    EXPECT_EQ(pdf.features.robustBufferAccess, VK_FALSE);
-    EXPECT_EQ(pdf.features.fullDrawIndexUint32, VK_TRUE);
-    EXPECT_EQ(pdf.features.imageCubeArray, VK_FALSE);
-    EXPECT_EQ(pdf.features.independentBlend, VK_TRUE);
-    EXPECT_EQ(pdf.features.geometryShader, VK_FALSE);
-    EXPECT_EQ(pdf.features.tessellationShader, VK_TRUE);
-    EXPECT_EQ(pdf.features.sampleRateShading, VK_FALSE);
-    EXPECT_EQ(pdf.features.dualSrcBlend, VK_TRUE);
-    EXPECT_EQ(pdf.features.logicOp, VK_FALSE);
-    EXPECT_EQ(pdf.features.multiDrawIndirect, VK_TRUE);
-    EXPECT_EQ(pdf.features.drawIndirectFirstInstance, VK_FALSE);
-    EXPECT_EQ(pdf.features.depthClamp, VK_FALSE);
-    EXPECT_EQ(pdf.features.depthBiasClamp, VK_TRUE);
-    EXPECT_EQ(pdf.features.fillModeNonSolid, VK_FALSE);
-    EXPECT_EQ(pdf.features.depthBounds, VK_TRUE);
-    EXPECT_EQ(pdf.features.wideLines, VK_FALSE);
-    EXPECT_EQ(pdf.features.largePoints, VK_TRUE);
-    EXPECT_EQ(pdf.features.alphaToOne, VK_FALSE);
-    EXPECT_EQ(pdf.features.multiViewport, VK_TRUE);
-    EXPECT_EQ(pdf.features.samplerAnisotropy, VK_FALSE);
-    EXPECT_EQ(pdf.features.textureCompressionETC2, VK_TRUE);
-    EXPECT_EQ(pdf.features.textureCompressionASTC_LDR, VK_FALSE);
-    EXPECT_EQ(pdf.features.textureCompressionBC, VK_TRUE);
-    EXPECT_EQ(pdf.features.occlusionQueryPrecise, VK_FALSE);
-    EXPECT_EQ(pdf.features.pipelineStatisticsQuery, VK_TRUE);
-    EXPECT_EQ(pdf.features.vertexPipelineStoresAndAtomics, VK_FALSE);
-    EXPECT_EQ(pdf.features.fragmentStoresAndAtomics, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderTessellationAndGeometryPointSize, VK_TRUE);
-    EXPECT_EQ(pdf.features.shaderImageGatherExtended, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderStorageImageExtendedFormats, VK_TRUE);
-    EXPECT_EQ(pdf.features.shaderStorageImageMultisample, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderStorageImageReadWithoutFormat, VK_TRUE);
-    EXPECT_EQ(pdf.features.shaderStorageImageWriteWithoutFormat, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderUniformBufferArrayDynamicIndexing, VK_TRUE);
-    EXPECT_EQ(pdf.features.shaderSampledImageArrayDynamicIndexing, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderStorageBufferArrayDynamicIndexing, VK_TRUE);
-    EXPECT_EQ(pdf.features.shaderStorageImageArrayDynamicIndexing, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderClipDistance, VK_TRUE);
-    EXPECT_EQ(pdf.features.shaderCullDistance, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderFloat64, VK_TRUE);
-    EXPECT_EQ(pdf.features.shaderInt64, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderInt16, VK_TRUE);
-    EXPECT_EQ(pdf.features.shaderResourceResidency, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderResourceMinLod, VK_TRUE);
-    EXPECT_EQ(pdf.features.sparseBinding, VK_FALSE);
-    EXPECT_EQ(pdf.features.sparseResidencyBuffer, VK_TRUE);
-    EXPECT_EQ(pdf.features.sparseResidencyImage2D, VK_FALSE);
-    EXPECT_EQ(pdf.features.sparseResidencyImage3D, VK_TRUE);
-    EXPECT_EQ(pdf.features.sparseResidency2Samples, VK_FALSE);
-    EXPECT_EQ(pdf.features.sparseResidency4Samples, VK_TRUE);
-    EXPECT_EQ(pdf.features.sparseResidency8Samples, VK_FALSE);
-    EXPECT_EQ(pdf.features.sparseResidency16Samples, VK_TRUE);
-    EXPECT_EQ(pdf.features.sparseResidencyAliased, VK_FALSE);
-    EXPECT_EQ(pdf.features.variableMultisampleRate, VK_TRUE);
-    EXPECT_EQ(pdf.features.inheritedQueries, VK_FALSE);
+    CompareStruct(ref_pdf, pdf);
 }
 
 TEST_F(Parse, VkGraphicsPipelineCreateInfo) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex compute pipeline create info JSON");
 
-    VkGraphicsPipelineCreateInfo gp_ci;
-    std::string json = {R"({
-            "sType" : "VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO",
-            "pNext": {
-                "sType": "VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT",
-                "pNext" : "NULL",
-                "flags": "0",
-                "discardRectangleMode": "VK_DISCARD_RECTANGLE_MODE_EXCLUSIVE_EXT",
-                "discardRectangleCount": 1,
-                "pDiscardRectangles": [
-                    {
-                        "offset":
-                        {
-                            "x" : 0,
-                            "y" : 0
-                        },
-                        "extent":
-                        {
-                            "width" : 51,
-                            "height" : 51
-                        }
-                    }
-                ]
-            },
-            "flags" : "0",
-            "stageCount" : 5,
-            "pStages": 
-            [
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                "pNext": {
-                    "pNext" : "NULL",
-                    "requiredSubgroupSize" : 64,
-                    "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO"
-                },
-                "flags" : "0",
-                "stage" : "VK_SHADER_STAGE_VERTEX_BIT",
-                "module" : 35,
-                "pName" : "main",
-                "pSpecializationInfo": 
-                "NULL"
-            },
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : "0",
-                "stage" : "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
-                "module" : 36,
-                "pName" : "main",
-                "pSpecializationInfo": 
-                "NULL"
-            },
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : "0",
-                "stage" : "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
-                "module" : 37,
-                "pName" : "main",
-                "pSpecializationInfo": 
-                "NULL"
-            },
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : "0",
-                "stage" : "VK_SHADER_STAGE_GEOMETRY_BIT",
-                "module" : 38,
-                "pName" : "main",
-                "pSpecializationInfo": 
-                "NULL"
-            },
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : "0",
-                "stage" : "VK_SHADER_STAGE_FRAGMENT_BIT",
-                "module" : 39,
-                "pName" : "main",
-                "pSpecializationInfo": 
-                "NULL"
-            }
-            ],
-)"
-                        R"(
-            "pVertexInputState": 
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : 0,
-                "vertexBindingDescriptionCount" : 1,
-                "pVertexBindingDescriptions": 
-                [
-                {
-                    "binding" : 0,
-                    "stride" : 32,
-                    "inputRate" : "VK_VERTEX_INPUT_RATE_VERTEX"
-                }
-                ],
-                "vertexAttributeDescriptionCount" : 2,
-                "pVertexAttributeDescriptions": 
-                [
-                {
-                    "location" : 0,
-                    "binding" : 0,
-                    "format" : "VK_FORMAT_R32G32B32A32_SFLOAT",
-                    "offset" : 0
-                },
-                {
-                    "location" : 1,
-                    "binding" : 0,
-                    "format" : "VK_FORMAT_R32G32B32A32_SFLOAT",
-                    "offset" : 16
-                }
-                ]
-            },
-            "pInputAssemblyState": 
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : 0,
-                "topology" : "VK_PRIMITIVE_TOPOLOGY_PATCH_LIST",
-                "primitiveRestartEnable" : "VK_FALSE"
-            },
-            "pTessellationState": 
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : 0,
-                "patchControlPoints" : 4
-            },
-)"
-                        R"(
-            "pViewportState": 
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : 0,
-                "viewportCount" : 1,
-                "pViewports": 
-                [
-                {
-                    "x" : 0,
-                    "y" : 0,
-                    "width" : 51,
-                    "height" : 51,
-                    "minDepth" : 0,
-                    "maxDepth" : 1
-                }
-                ],
-                "scissorCount" : 1,
-                "pScissors": 
-                [
-                {
-                    "offset": 
-                    {
-                        "x" : 0,
-                        "y" : 0
-                    },
-                    "extent": 
-                    {
-                        "width" : 51,
-                        "height" : 51
-                    }
-                }
-                ]
-            },
-            "pRasterizationState": 
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : 0,
-                "depthClampEnable" : "VK_FALSE",
-                "rasterizerDiscardEnable" : "VK_FALSE",
-                "polygonMode" : "VK_POLYGON_MODE_FILL",
-                "cullMode" : "0",
-                "frontFace" : "VK_FRONT_FACE_COUNTER_CLOCKWISE",
-                "depthBiasEnable" : "VK_FALSE",
-                "depthBiasConstantFactor" : 0,
-                "depthBiasClamp" : 0,
-                "depthBiasSlopeFactor" : 0,
-                "lineWidth" : 1
-            },
-            "pMultisampleState": 
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : 0,
-                "rasterizationSamples" : "VK_SAMPLE_COUNT_1_BIT",
-                "sampleShadingEnable" : "VK_FALSE",
-                "minSampleShading" : 1,
-                "pSampleMask":
-                "NULL",
-                "alphaToCoverageEnable" : "VK_FALSE",
-                "alphaToOneEnable" : "VK_FALSE"
-            },
-)"
-                        R"(
-            "pDepthStencilState": 
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : 0,
-                "depthTestEnable" : "VK_TRUE",
-                "depthWriteEnable" : "VK_TRUE",
-                "depthCompareOp" : "VK_COMPARE_OP_LESS_OR_EQUAL",
-                "depthBoundsTestEnable" : "VK_FALSE",
-                "stencilTestEnable" : "VK_FALSE",
-                "front": 
-                {
-                    "failOp" : "VK_STENCIL_OP_KEEP",
-                    "passOp" : "VK_STENCIL_OP_KEEP",
-                    "depthFailOp" : "VK_STENCIL_OP_KEEP",
-                    "compareOp" : "VK_COMPARE_OP_NEVER",
-                    "compareMask" : 0,
-                    "writeMask" : 0,
-                    "reference" : 0
-                },
-                "back": 
-                {
-                    "failOp" : "VK_STENCIL_OP_KEEP",
-                    "passOp" : "VK_STENCIL_OP_KEEP",
-                    "depthFailOp" : "VK_STENCIL_OP_KEEP",
-                    "compareOp" : "VK_COMPARE_OP_NEVER",
-                    "compareMask" : 0,
-                    "writeMask" : 0,
-                    "reference" : 0
-                },
-                "minDepthBounds" : 0,
-                "maxDepthBounds" : 1
-            },
-            "pColorBlendState": 
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : 0,
-                "logicOpEnable" : "VK_FALSE",
-                "logicOp" : "VK_LOGIC_OP_CLEAR",
-                "attachmentCount" : 1,
-                "pAttachments": 
-                [
-                {
-                    "blendEnable" : "VK_FALSE",
-                    "srcColorBlendFactor" : "VK_BLEND_FACTOR_ZERO",
-                    "dstColorBlendFactor" : "VK_BLEND_FACTOR_ZERO",
-                    "colorBlendOp" : "VK_BLEND_OP_ADD",
-                    "srcAlphaBlendFactor" : "VK_BLEND_FACTOR_ZERO",
-                    "dstAlphaBlendFactor" : "VK_BLEND_FACTOR_ZERO",
-                    "alphaBlendOp" : "VK_BLEND_OP_ADD",
-                    "colorWriteMask" : "VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT"
-                }
-                ],
-                "blendConstants":
-                [
-                0,
-                0,
-                0,
-                0
-                ]
-            },
-)"
-                        R"(
-            "pDynamicState": {
-                "sType": "VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO",
-                "pNext": "NULL",
-                "flags": 0,
-                "dynamicStateCount": 3,
-                "pDynamicStates": [
-                    "VK_DYNAMIC_STATE_VIEWPORT",
-                    "VK_DYNAMIC_STATE_SCISSOR",
-                    "VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT",
+    VkGraphicsPipelineCreateInfo ci{};
+    auto [ref_ci, json] = getVkGraphicsPipelineCreateInfo(
+        0,
+        {getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_VERTEX_BIT),
+         getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT),
+         getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT,
+                                            std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo())),
+         getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_GEOMETRY_BIT),
+         getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_FRAGMENT_BIT)},
+        std::make_tuple(getVkPipelineDiscardRectangleStateCreateInfoEXT()));
 
-                ]
-            },
-            "layout" : 8,
-            "renderPass" : 6,
-            "subpass" : 0,
-            "basePipelineHandle" : "",
-            "basePipelineIndex" : 0
-        })"};
-
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &gp_ci, &msg_));
-    const auto& pdrs_ci = *reinterpret_cast<const VkPipelineDiscardRectangleStateCreateInfoEXT*>(gp_ci.pNext);
-    const auto& pvis_ci = *reinterpret_cast<const VkPipelineVertexInputStateCreateInfo*>(gp_ci.pVertexInputState);
-    const auto& pias_ci = *reinterpret_cast<const VkPipelineInputAssemblyStateCreateInfo*>(gp_ci.pInputAssemblyState);
-    const auto& pts_ci = *reinterpret_cast<const VkPipelineTessellationStateCreateInfo*>(gp_ci.pTessellationState);
-    const auto& pvs_ci = *reinterpret_cast<const VkPipelineViewportStateCreateInfo*>(gp_ci.pViewportState);
-    const auto& prs_ci = *reinterpret_cast<const VkPipelineRasterizationStateCreateInfo*>(gp_ci.pRasterizationState);
-    const auto& pmss_ci = *reinterpret_cast<const VkPipelineMultisampleStateCreateInfo*>(gp_ci.pMultisampleState);
-    const auto& pdss_ci = *reinterpret_cast<const VkPipelineDepthStencilStateCreateInfo*>(gp_ci.pDepthStencilState);
-    const auto& pcbs_ci = *reinterpret_cast<const VkPipelineColorBlendStateCreateInfo*>(gp_ci.pColorBlendState);
-    const auto& pds_ci = *reinterpret_cast<const VkPipelineDynamicStateCreateInfo*>(gp_ci.pDynamicState);
-    const auto& pssrss_ci = *reinterpret_cast<const VkPipelineShaderStageRequiredSubgroupSizeCreateInfo*>(gp_ci.pStages[0].pNext);
-
-    EXPECT_EQ(gp_ci.sType, VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO);
-    EXPECT_EQ(pdrs_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT);
-    EXPECT_EQ(pdrs_ci.pNext, nullptr);
-    EXPECT_EQ(pdrs_ci.flags, 0);
-    EXPECT_EQ(pdrs_ci.discardRectangleMode, VK_DISCARD_RECTANGLE_MODE_EXCLUSIVE_EXT);
-    EXPECT_EQ(pdrs_ci.discardRectangleCount, 1);
-    EXPECT_EQ(pdrs_ci.pDiscardRectangles[0].offset.x, 0);
-    EXPECT_EQ(pdrs_ci.pDiscardRectangles[0].offset.y, 0);
-    EXPECT_EQ(pdrs_ci.pDiscardRectangles[0].extent.width, 51);
-    EXPECT_EQ(pdrs_ci.pDiscardRectangles[0].extent.height, 51);
-    EXPECT_EQ(gp_ci.flags, 0);
-    EXPECT_EQ(gp_ci.stageCount, 5);
-    EXPECT_EQ(gp_ci.pStages[0].sType, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO);
-    EXPECT_EQ(pssrss_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO);
-    EXPECT_EQ(pssrss_ci.pNext, nullptr);
-    EXPECT_EQ(pssrss_ci.requiredSubgroupSize, 64);
-    EXPECT_EQ(gp_ci.pStages[0].flags, 0);
-    EXPECT_EQ(gp_ci.pStages[0].stage, VK_SHADER_STAGE_VERTEX_BIT);
-    EXPECT_EQ(gp_ci.pStages[0].module, reinterpret_cast<void*>(35));
-    EXPECT_STREQ(gp_ci.pStages[0].pName, "main");
-    EXPECT_EQ(gp_ci.pStages[0].pSpecializationInfo, nullptr);
-    EXPECT_EQ(gp_ci.pStages[1].sType, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO);
-    EXPECT_EQ(gp_ci.pStages[1].pNext, nullptr);
-    EXPECT_EQ(gp_ci.pStages[1].flags, 0);
-    EXPECT_EQ(gp_ci.pStages[1].stage, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT);
-    EXPECT_EQ(gp_ci.pStages[1].module, reinterpret_cast<void*>(36));
-    EXPECT_STREQ(gp_ci.pStages[1].pName, "main");
-    EXPECT_EQ(gp_ci.pStages[1].pSpecializationInfo, nullptr);
-    EXPECT_EQ(gp_ci.pStages[2].sType, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO);
-    EXPECT_EQ(gp_ci.pStages[2].pNext, nullptr);
-    EXPECT_EQ(gp_ci.pStages[2].flags, 0);
-    EXPECT_EQ(gp_ci.pStages[2].stage, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT);
-    EXPECT_EQ(gp_ci.pStages[2].module, reinterpret_cast<void*>(37));
-    EXPECT_STREQ(gp_ci.pStages[2].pName, "main");
-    EXPECT_EQ(gp_ci.pStages[2].pSpecializationInfo, nullptr);
-    EXPECT_EQ(gp_ci.pStages[3].sType, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO);
-    EXPECT_EQ(gp_ci.pStages[3].pNext, nullptr);
-    EXPECT_EQ(gp_ci.pStages[3].flags, 0);
-    EXPECT_EQ(gp_ci.pStages[3].stage, VK_SHADER_STAGE_GEOMETRY_BIT);
-    EXPECT_EQ(gp_ci.pStages[3].module, reinterpret_cast<void*>(38));
-    EXPECT_STREQ(gp_ci.pStages[3].pName, "main");
-    EXPECT_EQ(gp_ci.pStages[3].pSpecializationInfo, nullptr);
-    EXPECT_EQ(gp_ci.pStages[4].sType, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO);
-    EXPECT_EQ(gp_ci.pStages[4].pNext, nullptr);
-    EXPECT_EQ(gp_ci.pStages[4].flags, 0);
-    EXPECT_EQ(gp_ci.pStages[4].stage, VK_SHADER_STAGE_FRAGMENT_BIT);
-    EXPECT_EQ(gp_ci.pStages[4].module, reinterpret_cast<void*>(39));
-    EXPECT_STREQ(gp_ci.pStages[4].pName, "main");
-    EXPECT_EQ(gp_ci.pStages[4].pSpecializationInfo, nullptr);
-    EXPECT_EQ(pvis_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO);
-    EXPECT_EQ(pvis_ci.pNext, nullptr);
-    EXPECT_EQ(pvis_ci.flags, 0);
-    EXPECT_EQ(pvis_ci.vertexBindingDescriptionCount, 1);
-    EXPECT_EQ(pvis_ci.pVertexBindingDescriptions[0].binding, 0);
-    EXPECT_EQ(pvis_ci.pVertexBindingDescriptions[0].stride, 32);
-    EXPECT_EQ(pvis_ci.pVertexBindingDescriptions[0].inputRate, VK_VERTEX_INPUT_RATE_VERTEX);
-    EXPECT_EQ(pvis_ci.vertexAttributeDescriptionCount, 2);
-    EXPECT_EQ(pvis_ci.pVertexAttributeDescriptions[0].location, 0);
-    EXPECT_EQ(pvis_ci.pVertexAttributeDescriptions[0].binding, 0);
-    EXPECT_EQ(pvis_ci.pVertexAttributeDescriptions[0].format, VK_FORMAT_R32G32B32A32_SFLOAT);
-    EXPECT_EQ(pvis_ci.pVertexAttributeDescriptions[0].offset, 0);
-    EXPECT_EQ(pvis_ci.pVertexAttributeDescriptions[1].location, 1);
-    EXPECT_EQ(pvis_ci.pVertexAttributeDescriptions[1].binding, 0);
-    EXPECT_EQ(pvis_ci.pVertexAttributeDescriptions[1].format, VK_FORMAT_R32G32B32A32_SFLOAT);
-    EXPECT_EQ(pvis_ci.pVertexAttributeDescriptions[1].offset, 16);
-    EXPECT_EQ(pias_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO);
-    EXPECT_EQ(pias_ci.pNext, nullptr);
-    EXPECT_EQ(pias_ci.flags, 0);
-    EXPECT_EQ(pias_ci.topology, VK_PRIMITIVE_TOPOLOGY_PATCH_LIST);
-    EXPECT_EQ(pias_ci.primitiveRestartEnable, VK_FALSE);
-    EXPECT_EQ(pts_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO);
-    EXPECT_EQ(pts_ci.pNext, nullptr);
-    EXPECT_EQ(pts_ci.flags, 0);
-    EXPECT_EQ(pts_ci.patchControlPoints, 4);
-    EXPECT_EQ(pvs_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO);
-    EXPECT_EQ(pvs_ci.pNext, nullptr);
-    EXPECT_EQ(pvs_ci.flags, 0);
-    EXPECT_EQ(pvs_ci.viewportCount, 1);
-    EXPECT_EQ(pvs_ci.pViewports[0].x, 0);
-    EXPECT_EQ(pvs_ci.pViewports[0].y, 0);
-    EXPECT_EQ(pvs_ci.pViewports[0].width, 51);
-    EXPECT_EQ(pvs_ci.pViewports[0].height, 51);
-    EXPECT_EQ(pvs_ci.pViewports[0].minDepth, 0);
-    EXPECT_EQ(pvs_ci.pViewports[0].maxDepth, 1);
-    EXPECT_EQ(pvs_ci.scissorCount, 1);
-    EXPECT_EQ(pvs_ci.pScissors[0].offset.x, 0);
-    EXPECT_EQ(pvs_ci.pScissors[0].offset.y, 0);
-    EXPECT_EQ(pvs_ci.pScissors[0].extent.width, 51);
-    EXPECT_EQ(pvs_ci.pScissors[0].extent.height, 51);
-    EXPECT_EQ(prs_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO);
-    EXPECT_EQ(prs_ci.pNext, nullptr);
-    EXPECT_EQ(prs_ci.flags, 0);
-    EXPECT_EQ(prs_ci.depthClampEnable, VK_FALSE);
-    EXPECT_EQ(prs_ci.rasterizerDiscardEnable, VK_FALSE);
-    EXPECT_EQ(prs_ci.polygonMode, VK_POLYGON_MODE_FILL);
-    EXPECT_EQ(prs_ci.cullMode, 0);
-    EXPECT_EQ(prs_ci.frontFace, VK_FRONT_FACE_COUNTER_CLOCKWISE);
-    EXPECT_EQ(prs_ci.depthBiasEnable, VK_FALSE);
-    EXPECT_EQ(prs_ci.depthBiasConstantFactor, 0);
-    EXPECT_EQ(prs_ci.depthBiasClamp, 0);
-    EXPECT_EQ(prs_ci.depthBiasSlopeFactor, 0);
-    EXPECT_EQ(prs_ci.lineWidth, 1);
-    EXPECT_EQ(pmss_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO);
-    EXPECT_EQ(pmss_ci.pNext, nullptr);
-    EXPECT_EQ(pmss_ci.flags, 0);
-    EXPECT_EQ(pmss_ci.rasterizationSamples, VK_SAMPLE_COUNT_1_BIT);
-    EXPECT_EQ(pmss_ci.sampleShadingEnable, VK_FALSE);
-    EXPECT_EQ(pmss_ci.minSampleShading, 1);
-    EXPECT_EQ(pmss_ci.pSampleMask, nullptr);
-    EXPECT_EQ(pmss_ci.alphaToCoverageEnable, VK_FALSE);
-    EXPECT_EQ(pmss_ci.alphaToOneEnable, VK_FALSE);
-    EXPECT_EQ(pdss_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO);
-    EXPECT_EQ(pdss_ci.pNext, nullptr);
-    EXPECT_EQ(pdss_ci.flags, 0);
-    EXPECT_EQ(pdss_ci.depthTestEnable, VK_TRUE);
-    EXPECT_EQ(pdss_ci.depthWriteEnable, VK_TRUE);
-    EXPECT_EQ(pdss_ci.depthCompareOp, VK_COMPARE_OP_LESS_OR_EQUAL);
-    EXPECT_EQ(pdss_ci.depthBoundsTestEnable, VK_FALSE);
-    EXPECT_EQ(pdss_ci.stencilTestEnable, VK_FALSE);
-    EXPECT_EQ(pdss_ci.front.failOp, VK_STENCIL_OP_KEEP);
-    EXPECT_EQ(pdss_ci.front.passOp, VK_STENCIL_OP_KEEP);
-    EXPECT_EQ(pdss_ci.front.depthFailOp, VK_STENCIL_OP_KEEP);
-    EXPECT_EQ(pdss_ci.front.compareOp, VK_COMPARE_OP_NEVER);
-    EXPECT_EQ(pdss_ci.front.compareMask, 0);
-    EXPECT_EQ(pdss_ci.front.writeMask, 0);
-    EXPECT_EQ(pdss_ci.front.reference, 0);
-    EXPECT_EQ(pdss_ci.back.failOp, VK_STENCIL_OP_KEEP);
-    EXPECT_EQ(pdss_ci.back.passOp, VK_STENCIL_OP_KEEP);
-    EXPECT_EQ(pdss_ci.back.depthFailOp, VK_STENCIL_OP_KEEP);
-    EXPECT_EQ(pdss_ci.back.compareOp, VK_COMPARE_OP_NEVER);
-    EXPECT_EQ(pdss_ci.back.compareMask, 0);
-    EXPECT_EQ(pdss_ci.back.writeMask, 0);
-    EXPECT_EQ(pdss_ci.back.reference, 0);
-    EXPECT_EQ(pdss_ci.minDepthBounds, 0);
-    EXPECT_EQ(pdss_ci.maxDepthBounds, 1);
-    EXPECT_EQ(pcbs_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO);
-    EXPECT_EQ(pcbs_ci.pNext, nullptr);
-    EXPECT_EQ(pcbs_ci.flags, 0);
-    EXPECT_EQ(pcbs_ci.logicOpEnable, VK_FALSE);
-    EXPECT_EQ(pcbs_ci.logicOp, VK_LOGIC_OP_CLEAR);
-    EXPECT_EQ(pcbs_ci.attachmentCount, 1);
-    EXPECT_EQ(pcbs_ci.pAttachments[0].blendEnable, VK_FALSE);
-    EXPECT_EQ(pcbs_ci.pAttachments[0].srcColorBlendFactor, VK_BLEND_FACTOR_ZERO);
-    EXPECT_EQ(pcbs_ci.pAttachments[0].dstColorBlendFactor, VK_BLEND_FACTOR_ZERO);
-    EXPECT_EQ(pcbs_ci.pAttachments[0].colorBlendOp, VK_BLEND_OP_ADD);
-    EXPECT_EQ(pcbs_ci.pAttachments[0].srcAlphaBlendFactor, VK_BLEND_FACTOR_ZERO);
-    EXPECT_EQ(pcbs_ci.pAttachments[0].dstAlphaBlendFactor, VK_BLEND_FACTOR_ZERO);
-    EXPECT_EQ(pcbs_ci.pAttachments[0].alphaBlendOp, VK_BLEND_OP_ADD);
-    EXPECT_EQ(pcbs_ci.pAttachments[0].colorWriteMask,
-              VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT);
-    EXPECT_EQ(pcbs_ci.blendConstants[0], 0);
-    EXPECT_EQ(pcbs_ci.blendConstants[1], 0);
-    EXPECT_EQ(pcbs_ci.blendConstants[2], 0);
-    EXPECT_EQ(pcbs_ci.blendConstants[3], 0);
-    EXPECT_EQ(pds_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO);
-    EXPECT_EQ(pds_ci.pNext, nullptr);
-    EXPECT_EQ(pds_ci.flags, 0);
-    EXPECT_EQ(pds_ci.dynamicStateCount, 3);
-    EXPECT_EQ(pds_ci.pDynamicStates[0], VK_DYNAMIC_STATE_VIEWPORT);
-    EXPECT_EQ(pds_ci.pDynamicStates[1], VK_DYNAMIC_STATE_SCISSOR);
-    EXPECT_EQ(pds_ci.pDynamicStates[2], VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT);
-    EXPECT_EQ(gp_ci.layout, reinterpret_cast<void*>(8));
-    EXPECT_EQ(gp_ci.renderPass, reinterpret_cast<void*>(6));
-    EXPECT_EQ(gp_ci.subpass, 0);
-    EXPECT_EQ(gp_ci.basePipelineHandle, VK_NULL_HANDLE);
-    EXPECT_EQ(gp_ci.basePipelineIndex, 0);
+    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &ci, &msg_));
+    CompareStruct(ref_ci, ci);
 }
 
 TEST_F(Parse, VkComputePipelineCreateInfo) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex compute pipeline create info JSON");
 
-    VkComputePipelineCreateInfo cp_ci;
-    std::string json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO",
-        "pNext": "NULL",
-        "flags" : "0",
-        "stage":
-        {
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-            "pNext": {
-                "sType": "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO",
-                "pNext": "NULL",
-                "requiredSubgroupSize": 64
-            },
-            "flags" : "VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT",
-            "stage" : "VK_SHADER_STAGE_COMPUTE_BIT",
-            "pName" : "main",
-            "pSpecializationInfo": {
-                "mapEntryCount": 1,
-                "pMapEntries": [
-                    {
-                        "constantID": 0,
-                        "offset": 0,
-                        "size": 4
-                    }
-                ],
-                "dataSize": 4,
-                "pData": [ 0, 1, 2, 3 ]
-            },
-            "module": ""
-        },
-        "layout" : 9,
-        "basePipelineHandle" : "",
-        "basePipelineIndex" : 0
-    })"};
+    VkComputePipelineCreateInfo ci{};
+    auto [ref_ci, json] = getVkComputePipelineCreateInfo(getVkPipelineShaderStageCreateInfo(
+        0, VK_SHADER_STAGE_COMPUTE_BIT, std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo())));
 
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &cp_ci, &msg_));
-    const auto& pssrss_ci = *reinterpret_cast<const VkPipelineShaderStageRequiredSubgroupSizeCreateInfo*>(cp_ci.stage.pNext);
-
-    EXPECT_EQ(cp_ci.sType, VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO);
-    EXPECT_EQ(cp_ci.pNext, nullptr);
-    EXPECT_EQ(cp_ci.flags, 0);
-    EXPECT_EQ(cp_ci.stage.sType, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO);
-    EXPECT_NE(cp_ci.stage.pNext, nullptr);
-    EXPECT_EQ(pssrss_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO);
-    EXPECT_EQ(pssrss_ci.pNext, nullptr);
-    EXPECT_EQ(pssrss_ci.requiredSubgroupSize, 64);
-    EXPECT_EQ(cp_ci.stage.flags, VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT);
-    EXPECT_EQ(cp_ci.stage.stage, VK_SHADER_STAGE_COMPUTE_BIT);
-    EXPECT_STREQ(cp_ci.stage.pName, "main");
-    EXPECT_EQ(cp_ci.stage.pSpecializationInfo->mapEntryCount, 1);
-    EXPECT_EQ(cp_ci.stage.pSpecializationInfo->pMapEntries[0].constantID, 0);
-    EXPECT_EQ(cp_ci.stage.pSpecializationInfo->pMapEntries[0].offset, 0);
-    EXPECT_EQ(cp_ci.stage.pSpecializationInfo->pMapEntries[0].size, 4);
-    EXPECT_EQ(cp_ci.stage.pSpecializationInfo->dataSize, 4);
-    EXPECT_EQ(reinterpret_cast<const uint8_t*>(cp_ci.stage.pSpecializationInfo->pData)[0], 0);
-    EXPECT_EQ(reinterpret_cast<const uint8_t*>(cp_ci.stage.pSpecializationInfo->pData)[1], 1);
-    EXPECT_EQ(reinterpret_cast<const uint8_t*>(cp_ci.stage.pSpecializationInfo->pData)[2], 2);
-    EXPECT_EQ(reinterpret_cast<const uint8_t*>(cp_ci.stage.pSpecializationInfo->pData)[3], 3);
-    EXPECT_EQ(cp_ci.stage.module, VK_NULL_HANDLE);
-    EXPECT_EQ(cp_ci.layout, reinterpret_cast<void*>(9));
-    EXPECT_EQ(cp_ci.basePipelineHandle, VK_NULL_HANDLE);
-    EXPECT_EQ(cp_ci.basePipelineIndex, 0);
+    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &ci, &msg_));
+    CompareStruct(ref_ci, ci);
 }
 
 TEST_F(Parse, VkSamplerYcbcrConversionCreateInfo) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex ycbcr conversion create info JSON");
 
-#ifdef VK_USE_PLATFORM_SCREEN_QNX
-    std::string ycbcr_ci_pnext = R"({
-            "sType" : "VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_QNX",
-            "pNext": "NULL",
-            "externalFormat": 10
-    })";
-#else
-    std::string ycbcr_ci_pnext = R"("NULL")";
-#endif  // VK_USE_PLATFORM_SCREEN_QNX
+    VkSamplerYcbcrConversionCreateInfo ci{};
+    auto [ref_ci, json] = getVkSamplerYcbcrConversionCreateInfo();
 
-    VkSamplerYcbcrConversionCreateInfo ycbcr_ci;
-    std::string json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO",
-        "pNext": )" + ycbcr_ci_pnext +
-                        R"(,
-        "format": "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16",
-        "ycbcrModel": "VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020",
-        "ycbcrRange": "VK_SAMPLER_YCBCR_RANGE_ITU_NARROW",
-        "components": {
-            "r": "VK_COMPONENT_SWIZZLE_A",
-            "g": "VK_COMPONENT_SWIZZLE_B",
-            "b": "VK_COMPONENT_SWIZZLE_G",
-            "a": "VK_COMPONENT_SWIZZLE_R",
-        },
-        "xChromaOffset": "VK_CHROMA_LOCATION_COSITED_EVEN",
-        "yChromaOffset": "VK_CHROMA_LOCATION_MIDPOINT",
-        "chromaFilter": "VK_FILTER_CUBIC_EXT",
-        "forceExplicitReconstruction": "VK_TRUE"
-    })"};
-
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &ycbcr_ci, &msg_));
-#ifdef VK_USE_PLATFORM_SCREEN_QNX
-    const auto& ef_qnx = *reinterpret_cast<const VkExternalFormatQNX*>(ycbcr_ci.pNext);
-#endif  // VK_USE_PLATFORM_SCREEN_QNX
-
-    EXPECT_EQ(ycbcr_ci.sType, VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO);
-#ifdef VK_USE_PLATFORM_SCREEN_QNX
-    EXPECT_EQ(ef_qnx.sType, VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_QNX);
-    EXPECT_EQ(ef_qnx.pNext, nullptr);
-    EXPECT_EQ(ef_qnx.externalFormat, 10);
-#else
-    EXPECT_EQ(ycbcr_ci.pNext, nullptr);
-#endif  // VK_USE_PLATFORM_SCREEN_QNX
-    EXPECT_EQ(ycbcr_ci.format, VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16);
-    EXPECT_EQ(ycbcr_ci.ycbcrModel, VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020);
-    EXPECT_EQ(ycbcr_ci.ycbcrRange, VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
-    EXPECT_EQ(ycbcr_ci.components.r, VK_COMPONENT_SWIZZLE_A);
-    EXPECT_EQ(ycbcr_ci.components.g, VK_COMPONENT_SWIZZLE_B);
-    EXPECT_EQ(ycbcr_ci.components.b, VK_COMPONENT_SWIZZLE_G);
-    EXPECT_EQ(ycbcr_ci.components.a, VK_COMPONENT_SWIZZLE_R);
-    EXPECT_EQ(ycbcr_ci.xChromaOffset, VK_CHROMA_LOCATION_COSITED_EVEN);
-    EXPECT_EQ(ycbcr_ci.yChromaOffset, VK_CHROMA_LOCATION_MIDPOINT);
-    EXPECT_EQ(ycbcr_ci.chromaFilter, VK_FILTER_CUBIC_EXT);
-    EXPECT_EQ(ycbcr_ci.forceExplicitReconstruction, VK_TRUE);
+    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &ci, &msg_));
+    CompareStruct(ref_ci, ci);
 }
 
 TEST_F(Parse, VkSamplerCreateInfo) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex sampler create info JSON");
 
-    VkSamplerCreateInfo sampler_ci;
-    std::string json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO",
-        "pNext": {
-            "sType" : "VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO",
-            "pNext": "NULL",
-            "reductionMode": "VK_SAMPLER_REDUCTION_MODE_MAX"
-        },
-        "flags": 0,
-        "magFilter": "VK_FILTER_CUBIC_EXT",
-        "minFilter": "VK_FILTER_NEAREST",
-        "mipmapMode": "VK_SAMPLER_MIPMAP_MODE_LINEAR",
-        "addressModeU": "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-        "addressModeV": "VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT",
-        "addressModeW": "VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE",
-        "mipLodBias": 0.8,
-        "anisotropyEnable": "VK_FALSE",
-        "maxAnisotropy": 1.8,
-        "compareEnable": "VK_FALSE",
-        "compareOp": 137,
-        "minLod": "NaN",
-        "maxLod": "VK_LOD_CLAMP_NONE",
-        "borderColor": "VK_BORDER_COLOR_FLOAT_CUSTOM_EXT",
-        "unnormalizedCoordinates": "VK_TRUE"
-    })"};
+    VkSamplerCreateInfo ci{};
+    auto [ref_ci, json] = getVkSamplerCreateInfo(
+        1,
+        std::make_tuple(getVkSamplerYcbcrConversionInfo(VkSamplerYcbcrConversion(12345)), getVkSamplerReductionModeCreateInfo(1)));
 
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &sampler_ci, &msg_));
-    const auto& srm_ci = *reinterpret_cast<const VkSamplerReductionModeCreateInfo*>(sampler_ci.pNext);
-
-    EXPECT_EQ(sampler_ci.sType, VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO);
-    EXPECT_EQ(srm_ci.sType, VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO);
-    EXPECT_EQ(srm_ci.pNext, nullptr);
-    EXPECT_EQ(srm_ci.reductionMode, VK_SAMPLER_REDUCTION_MODE_MAX);
-    EXPECT_EQ(sampler_ci.flags, 0);
-    EXPECT_EQ(sampler_ci.magFilter, VK_FILTER_CUBIC_EXT);
-    EXPECT_EQ(sampler_ci.minFilter, VK_FILTER_NEAREST);
-    EXPECT_EQ(sampler_ci.mipmapMode, VK_SAMPLER_MIPMAP_MODE_LINEAR);
-    EXPECT_EQ(sampler_ci.addressModeU, VK_SAMPLER_ADDRESS_MODE_REPEAT);
-    EXPECT_EQ(sampler_ci.addressModeV, VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT);
-    EXPECT_EQ(sampler_ci.addressModeW, VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE);
-    EXPECT_EQ(sampler_ci.mipLodBias, 0.8f);
-    EXPECT_EQ(sampler_ci.anisotropyEnable, VK_FALSE);
-    EXPECT_EQ(sampler_ci.maxAnisotropy, 1.8f);
-    EXPECT_EQ(sampler_ci.compareEnable, VK_FALSE);
-    EXPECT_EQ(sampler_ci.compareOp, 137);
-    EXPECT_TRUE(std::isnan(sampler_ci.minLod));
-    EXPECT_EQ(sampler_ci.maxLod, VK_LOD_CLAMP_NONE);
-    EXPECT_EQ(sampler_ci.borderColor, VK_BORDER_COLOR_FLOAT_CUSTOM_EXT);
-    EXPECT_EQ(sampler_ci.unnormalizedCoordinates, VK_TRUE);
+    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &ci, &msg_));
+    CompareStruct(ref_ci, ci);
 }
 
 TEST_F(Parse, VkDescriptorSetLayoutCreateInfo) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex descriptor set layout create info JSON");
 
-    VkDescriptorSetLayoutCreateInfo dsl_ci;
-    std::string json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO",
-        "pNext": {
-            "sType" : "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO",
-            "pNext": "NULL",
-            "bindingCount": 1,
-            "pBindingFlags": [
-                "VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT"
-            ]
-        },
-        "flags": "VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT",
-        "bindingCount": 1,
-        "pBindings": [
-            {
-                "binding": 12345,
-                "descriptorType": "VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER",
-                "descriptorCount": 1,
-                "stageFlags": "VK_SHADER_STAGE_ALL",
-                "pImmutableSamplers": "NULL"
-            }
-        ]
-    })"};
+    VkDescriptorSetLayoutCreateInfo ci{};
+    auto [ref_ci, json] = getVkDescriptorSetLayoutCreateInfo(0,
+                                                             {{1, VK_SHADER_STAGE_VERTEX_BIT},
+                                                              {1, VK_SHADER_STAGE_FRAGMENT_BIT, VkSampler(1)},
+                                                              {1, VK_SHADER_STAGE_FRAGMENT_BIT, VkSampler(2)}},
+                                                             std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
 
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &dsl_ci, &msg_));
-    const auto& dslbf_ci = *reinterpret_cast<const VkDescriptorSetLayoutBindingFlagsCreateInfo*>(dsl_ci.pNext);
-
-    EXPECT_EQ(dsl_ci.sType, VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO);
-    EXPECT_EQ(dslbf_ci.sType, VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO);
-    EXPECT_EQ(dslbf_ci.pNext, nullptr);
-    EXPECT_EQ(dslbf_ci.bindingCount, 1);
-    EXPECT_EQ(dslbf_ci.pBindingFlags[0], VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT);
-    EXPECT_EQ(dsl_ci.flags, VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT);
-    EXPECT_EQ(dsl_ci.bindingCount, 1);
-    EXPECT_EQ(dsl_ci.pBindings[0].binding, 12345);
-    EXPECT_EQ(dsl_ci.pBindings[0].descriptorType, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
-    EXPECT_EQ(dsl_ci.pBindings[0].descriptorCount, 1);
-    EXPECT_EQ(dsl_ci.pBindings[0].stageFlags, VK_SHADER_STAGE_ALL);
-    EXPECT_EQ(dsl_ci.pBindings[0].pImmutableSamplers, nullptr);
+    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &ci, &msg_));
+    CompareStruct(ref_ci, ci);
 }
 
 TEST_F(Parse, VkPipelineLayoutCreateInfo) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex pipeline layout create info JSON");
 
-    VkPipelineLayoutCreateInfo pl_ci;
-    std::string json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO",
-        "pNext": "NULL",
-        "flags": 0,
-        "setLayoutCount": 1,
-        "pSetLayouts": [
-            54321
-        ],
-        "pushConstantRangeCount": 1,
-        "pPushConstantRanges": [
-            {
-                "stageFlags": "VK_SHADER_STAGE_COMPUTE_BIT | VK_SHADER_STAGE_ALL_GRAPHICS",
-                "offset": 0,
-                "size": 8
-            }
-        ]
-    })"};
+    VkPipelineLayoutCreateInfo ci;
+    auto [ref_ci, json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(12345)}});
 
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &pl_ci, &msg_));
-
-    EXPECT_EQ(pl_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO);
-    EXPECT_EQ(pl_ci.pNext, nullptr);
-    EXPECT_EQ(pl_ci.flags, 0);
-    EXPECT_EQ(pl_ci.setLayoutCount, 1);
-    EXPECT_EQ((size_t)pl_ci.pSetLayouts[0], 54321);
-    EXPECT_EQ(pl_ci.pushConstantRangeCount, 1);
-    EXPECT_EQ(pl_ci.pPushConstantRanges[0].stageFlags, VK_SHADER_STAGE_COMPUTE_BIT | VK_SHADER_STAGE_ALL_GRAPHICS);
-    EXPECT_EQ(pl_ci.pPushConstantRanges[0].offset, 0);
-    EXPECT_EQ(pl_ci.pPushConstantRanges[0].size, 8);
+    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &ci, &msg_));
+    CompareStruct(ref_ci, ci);
 }
 
 TEST_F(Parse, VkRenderPassCreateInfo) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex render pass create info JSON");
 
-    VkRenderPassCreateInfo rp_ci;
-    std::string json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO",
-        "pNext": {
-            "sType" : "VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO",
-            "pNext": {
-                "sType" : "VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO",
-                "pNext": "NULL",
-                "subpassCount": 1,
-                "pViewMasks": [ 1 ],
-                "dependencyCount": 2,
-                "pViewOffsets": [ 0, 1 ],
-                "correlationMaskCount": 1,
-                "pCorrelationMasks": [ 8 ]
-            },
-            "aspectReferenceCount": 1,
-            "pAspectReferences": [
-                {
-                    "subpass": 1,
-                    "inputAttachmentIndex": 2,
-                    "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
-                }
-            ]
-        },
-        "flags": 0,
-        "attachmentCount": 1,
-        "pAttachments": [
-            {
-                "flags": "VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT",
-                "format": "VK_FORMAT_R8G8_USCALED",
-                "samples": "VK_SAMPLE_COUNT_8_BIT",
-                "loadOp": "VK_ATTACHMENT_LOAD_OP_DONT_CARE",
-                "storeOp": "VK_ATTACHMENT_STORE_OP_STORE",
-                "stencilLoadOp": "VK_ATTACHMENT_LOAD_OP_LOAD",
-                "stencilStoreOp": "VK_ATTACHMENT_STORE_OP_DONT_CARE",
-                "initialLayout": "VK_IMAGE_LAYOUT_GENERAL",
-                "finalLayout": "VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR"
-            }
-        ],
-        "subpassCount": 2,
-        "pSubpasses": [
-            {
-                "flags": 0,
-                "pipelineBindPoint": "VK_PIPELINE_BIND_POINT_GRAPHICS",
-                "inputAttachmentCount": 1,
-                "pInputAttachments": [
-                    {
-                        "attachment": 567,
-                        "layout": "VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL"
-                    }
-                ],
-                "colorAttachmentCount": 1,
-                "pColorAttachments": [
-                    {
-                        "attachment": "VK_ATTACHMENT_UNUSED",
-                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED"
-                    }
-                ],
-                "pResolveAttachments": [
-                    {
-                        "attachment": "VK_ATTACHMENT_UNUSED",
-                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED"
-                    }
-                ],
-                "pDepthStencilAttachment": {
-                    "attachment": "VK_ATTACHMENT_UNUSED",
-                    "layout": "VK_IMAGE_LAYOUT_UNDEFINED"
-                },
-                "preserveAttachmentCount": 0,
-                "pPreserveAttachments": "NULL"
-            },
-            {
-                "flags": 0,
-                "pipelineBindPoint": "VK_PIPELINE_BIND_POINT_GRAPHICS",
-                "inputAttachmentCount": 0,
-                "pInputAttachments": "NULL",
-                "colorAttachmentCount": 1,
-                "pColorAttachments": [
-                    {
-                        "attachment": 567,
-                        "layout": "VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL_KHR"
-                    }
-                ],
-                "pResolveAttachments": [
-                    {
-                        "attachment": "VK_ATTACHMENT_UNUSED",
-                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED"
-                    }
-                ],
-                "pDepthStencilAttachment": {
-                    "attachment": "VK_ATTACHMENT_UNUSED",
-                    "layout": "VK_IMAGE_LAYOUT_UNDEFINED"
-                },
-                "preserveAttachmentCount": 0,
-                "pPreserveAttachments": "NULL"
-            }
-        ],
-        "dependencyCount": 1,
-        "pDependencies": [
-            {
-                "srcSubpass": "VK_SUBPASS_EXTERNAL",
-                "dstSubpass": 2345,
-                "srcStageMask": "VK_PIPELINE_STAGE_NONE_KHR",
-                "dstStageMask": "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "srcAccessMask": "VK_ACCESS_NONE_KHR",
-                "dstAccessMask": "VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT",
-                "dependencyFlags": "VK_DEPENDENCY_DEVICE_GROUP_BIT"
-            }
-        ]
-    })"};
+    VkRenderPassCreateInfo ci;
+    auto [ref_ci, json] = getVkRenderPassCreateInfo(
+        0, std::make_tuple(getVkRenderPassInputAttachmentAspectCreateInfo(), getVkRenderPassMultiviewCreateInfo()));
 
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &rp_ci, &msg_));
-    const auto& rpiaa_ci = *reinterpret_cast<const VkRenderPassInputAttachmentAspectCreateInfo*>(rp_ci.pNext);
-    const auto& rpmv_ci = *reinterpret_cast<const VkRenderPassMultiviewCreateInfo*>(rpiaa_ci.pNext);
-
-    EXPECT_EQ(rp_ci.sType, VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO);
-    EXPECT_EQ(rpiaa_ci.sType, VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO);
-    EXPECT_EQ(rpiaa_ci.aspectReferenceCount, 1);
-    EXPECT_EQ(rpiaa_ci.pAspectReferences[0].subpass, 1);
-    EXPECT_EQ(rpiaa_ci.pAspectReferences[0].inputAttachmentIndex, 2);
-    EXPECT_EQ(rpiaa_ci.pAspectReferences[0].aspectMask, VK_IMAGE_ASPECT_COLOR_BIT);
-    EXPECT_EQ(rpmv_ci.sType, VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO);
-    EXPECT_EQ(rpmv_ci.pNext, nullptr);
-    EXPECT_EQ(rpmv_ci.subpassCount, 1);
-    EXPECT_EQ(rpmv_ci.pViewMasks[0], 1);
-    EXPECT_EQ(rpmv_ci.dependencyCount, 2);
-    EXPECT_EQ(rpmv_ci.pViewOffsets[0], 0);
-    EXPECT_EQ(rpmv_ci.pViewOffsets[1], 1);
-    EXPECT_EQ(rpmv_ci.correlationMaskCount, 1);
-    EXPECT_EQ(rpmv_ci.pCorrelationMasks[0], 8);
-    EXPECT_EQ(rp_ci.flags, 0);
-    EXPECT_EQ(rp_ci.attachmentCount, 1);
-    EXPECT_EQ(rp_ci.pAttachments[0].flags, VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT);
-    EXPECT_EQ(rp_ci.pAttachments[0].format, VK_FORMAT_R8G8_USCALED);
-    EXPECT_EQ(rp_ci.pAttachments[0].samples, VK_SAMPLE_COUNT_8_BIT);
-    EXPECT_EQ(rp_ci.pAttachments[0].loadOp, VK_ATTACHMENT_LOAD_OP_DONT_CARE);
-    EXPECT_EQ(rp_ci.pAttachments[0].storeOp, VK_ATTACHMENT_STORE_OP_STORE);
-    EXPECT_EQ(rp_ci.pAttachments[0].stencilLoadOp, VK_ATTACHMENT_LOAD_OP_LOAD);
-    EXPECT_EQ(rp_ci.pAttachments[0].stencilStoreOp, VK_ATTACHMENT_STORE_OP_DONT_CARE);
-    EXPECT_EQ(rp_ci.pAttachments[0].initialLayout, VK_IMAGE_LAYOUT_GENERAL);
-    EXPECT_EQ(rp_ci.pAttachments[0].finalLayout, VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR);
-    EXPECT_EQ(rp_ci.subpassCount, 2);
-    EXPECT_EQ(rp_ci.pSubpasses[0].flags, 0);
-    EXPECT_EQ(rp_ci.pSubpasses[0].pipelineBindPoint, VK_PIPELINE_BIND_POINT_GRAPHICS);
-    EXPECT_EQ(rp_ci.pSubpasses[0].inputAttachmentCount, 1);
-    EXPECT_EQ(rp_ci.pSubpasses[0].pInputAttachments[0].attachment, 567);
-    EXPECT_EQ(rp_ci.pSubpasses[0].pInputAttachments[0].layout, VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL);
-    EXPECT_EQ(rp_ci.pSubpasses[0].colorAttachmentCount, 1);
-    EXPECT_EQ(rp_ci.pSubpasses[0].pColorAttachments[0].attachment, VK_ATTACHMENT_UNUSED);
-    EXPECT_EQ(rp_ci.pSubpasses[0].pColorAttachments[0].layout, VK_IMAGE_LAYOUT_UNDEFINED);
-    EXPECT_EQ(rp_ci.pSubpasses[0].pResolveAttachments[0].attachment, VK_ATTACHMENT_UNUSED);
-    EXPECT_EQ(rp_ci.pSubpasses[0].pResolveAttachments[0].layout, VK_IMAGE_LAYOUT_UNDEFINED);
-    EXPECT_EQ(rp_ci.pSubpasses[0].pDepthStencilAttachment[0].attachment, VK_ATTACHMENT_UNUSED);
-    EXPECT_EQ(rp_ci.pSubpasses[0].pDepthStencilAttachment[0].layout, VK_IMAGE_LAYOUT_UNDEFINED);
-    EXPECT_EQ(rp_ci.pSubpasses[0].preserveAttachmentCount, 0);
-    EXPECT_EQ(rp_ci.pSubpasses[0].pPreserveAttachments, nullptr);
-    EXPECT_EQ(rp_ci.pSubpasses[1].flags, 0);
-    EXPECT_EQ(rp_ci.pSubpasses[1].pipelineBindPoint, VK_PIPELINE_BIND_POINT_GRAPHICS);
-    EXPECT_EQ(rp_ci.pSubpasses[1].inputAttachmentCount, 0);
-    EXPECT_EQ(rp_ci.pSubpasses[1].pInputAttachments, nullptr);
-    EXPECT_EQ(rp_ci.pSubpasses[1].colorAttachmentCount, 1);
-    EXPECT_EQ(rp_ci.pSubpasses[1].pColorAttachments[0].attachment, 567);
-    EXPECT_EQ(rp_ci.pSubpasses[1].pColorAttachments[0].layout, VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL_KHR);
-    EXPECT_EQ(rp_ci.pSubpasses[1].pResolveAttachments[0].attachment, VK_ATTACHMENT_UNUSED);
-    EXPECT_EQ(rp_ci.pSubpasses[1].pResolveAttachments[0].layout, VK_IMAGE_LAYOUT_UNDEFINED);
-    EXPECT_EQ(rp_ci.pSubpasses[1].pDepthStencilAttachment[0].attachment, VK_ATTACHMENT_UNUSED);
-    EXPECT_EQ(rp_ci.pSubpasses[1].pDepthStencilAttachment[0].layout, VK_IMAGE_LAYOUT_UNDEFINED);
-    EXPECT_EQ(rp_ci.pSubpasses[1].preserveAttachmentCount, 0);
-    EXPECT_EQ(rp_ci.pSubpasses[1].pPreserveAttachments, nullptr);
-    EXPECT_EQ(rp_ci.dependencyCount, 1);
-    EXPECT_EQ(rp_ci.pDependencies[0].srcSubpass, VK_SUBPASS_EXTERNAL);
-    EXPECT_EQ(rp_ci.pDependencies[0].dstSubpass, 2345);
-    EXPECT_EQ(rp_ci.pDependencies[0].srcStageMask, VK_PIPELINE_STAGE_NONE_KHR);
-    EXPECT_EQ(rp_ci.pDependencies[0].dstStageMask, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
-    EXPECT_EQ(rp_ci.pDependencies[0].srcAccessMask, VK_ACCESS_NONE_KHR);
-    EXPECT_EQ(rp_ci.pDependencies[0].dstAccessMask, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
-    EXPECT_EQ(rp_ci.pDependencies[0].dependencyFlags, VK_DEPENDENCY_DEVICE_GROUP_BIT);
+    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &ci, &msg_));
+    CompareStruct(ref_ci, ci);
 }
 
 TEST_F(Parse, VkRenderPassCreateInfo2) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex render pass 2 layout create info JSON");
 
-    VkRenderPassCreateInfo2 rp2_ci;
-    std::string json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2",
-        "pNext": "NULL",
-        "flags": 0,
-        "attachmentCount": 1,
-        "pAttachments": [
-            {
-                "sType" : "VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2",
-                "pNext": {
-                    "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT",
-                    "pNext": "NULL",
-                    "stencilInitialLayout": "VK_IMAGE_LAYOUT_GENERAL",
-                    "stencilFinalLayout": "VK_IMAGE_LAYOUT_GENERAL"
-                },
-                "flags": "VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT",
-                "format": "VK_FORMAT_R8G8_USCALED",
-                "samples": "VK_SAMPLE_COUNT_8_BIT",
-                "loadOp": "VK_ATTACHMENT_LOAD_OP_DONT_CARE",
-                "storeOp": "VK_ATTACHMENT_STORE_OP_STORE",
-                "stencilLoadOp": "VK_ATTACHMENT_LOAD_OP_LOAD",
-                "stencilStoreOp": "VK_ATTACHMENT_STORE_OP_DONT_CARE",
-                "initialLayout": "VK_IMAGE_LAYOUT_GENERAL",
-                "finalLayout": "VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR"
-            }
-        ],
-        "subpassCount": 2,
-        "pSubpasses": [
-            {
-                "sType" : "VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2",
-                "pNext": {
-                    "sType" : "VK_STRUCTURE_TYPE_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR",
-                    "pNext": {
-                        "sType" : "VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE",
-                        "pNext": "NULL",
-                        "depthResolveMode": "VK_RESOLVE_MODE_MIN_BIT",
-                        "stencilResolveMode": "VK_RESOLVE_MODE_MAX_BIT",
-                        "pDepthStencilResolveAttachment": {
-                            "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
-                            "pNext": "NULL",
-                            "attachment": 8,
-                            "layout": "VK_IMAGE_LAYOUT_GENERAL",
-                            "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
-                        }
-                    },
-                    "pFragmentShadingRateAttachment": {
-                        "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
-                        "pNext": "NULL",
-                        "attachment": 5,
-                        "layout": "VK_IMAGE_LAYOUT_GENERAL",
-                        "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
-                    },
-                    "shadingRateAttachmentTexelSize": {
-                        "width": 4,
-                        "height": 4
-                    }
-                },
-                "flags": 0,
-                "pipelineBindPoint": "VK_PIPELINE_BIND_POINT_GRAPHICS",
-                "viewMask": 0,
-                "inputAttachmentCount": 1,
-                "pInputAttachments": [
-                    {
-                        "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
-                        "pNext": "NULL",
-                        "attachment": 567,
-                        "layout": "VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL",
-                        "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
-                    }
-                ],
-                "colorAttachmentCount": 1,
-                "pColorAttachments": [
-                    {
-                        "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
-                        "pNext": "NULL",
-                        "attachment": "VK_ATTACHMENT_UNUSED",
-                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED",
-                        "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
-                    }
-                ],
-                "pResolveAttachments": [
-                    {
-                        "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
-                        "pNext": "NULL",
-                        "attachment": "VK_ATTACHMENT_UNUSED",
-                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED",
-                        "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
-                    }
-                ],
-                "pDepthStencilAttachment": {
-                    "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
-                    "pNext": "NULL",
-                    "attachment": "VK_ATTACHMENT_UNUSED",
-                    "layout": "VK_IMAGE_LAYOUT_UNDEFINED",
-                    "aspectMask": "VK_IMAGE_ASPECT_DEPTH_BIT"
-                },
-                "preserveAttachmentCount": 0,
-                "pPreserveAttachments": "NULL"
-            },
-            {
-                "sType" : "VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2",
-                "pNext": "NULL",
-                "flags": 0,
-                "pipelineBindPoint": "VK_PIPELINE_BIND_POINT_GRAPHICS",
-                "viewMask": 0,
-                "inputAttachmentCount": 0,
-                "pInputAttachments": "NULL",
-                "colorAttachmentCount": 1,
-                "pColorAttachments": [
-                    {
-                        "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
-                        "pNext": "NULL",
-                        "attachment": 567,
-                        "layout": "VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL_KHR",
-                        "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
-                    }
-                ],
-                "pResolveAttachments": [
-                    {
-                        "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
-                        "pNext": "NULL",
-                        "attachment": "VK_ATTACHMENT_UNUSED",
-                        "layout": "VK_IMAGE_LAYOUT_UNDEFINED",
-                        "aspectMask": "VK_IMAGE_ASPECT_COLOR_BIT"
-                    }
-                ],
-                "pDepthStencilAttachment": {
-                    "sType": "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
-                    "pNext": "NULL",
-                    "attachment": "VK_ATTACHMENT_UNUSED",
-                    "layout": "VK_IMAGE_LAYOUT_UNDEFINED",
-                    "aspectMask": "VK_IMAGE_ASPECT_DEPTH_BIT"
-                },
-                "preserveAttachmentCount": 0,
-                "pPreserveAttachments": "NULL"
-            }
-        ],
-        "dependencyCount": 1,
-        "pDependencies": [
-            {
-                "sType" : "VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2",
-                "pNext": {
-                    "sType" : "VK_STRUCTURE_TYPE_MEMORY_BARRIER_2_KHR",
-                    "pNext": "NULL",
-                    "srcStageMask": "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
-                    "srcAccessMask": "VK_ACCESS_2_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT",
-                    "dstStageMask": "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
-                    "dstAccessMask": "VK_ACCESS_2_COMMAND_PREPROCESS_READ_BIT_NV"
-                },
-                "srcSubpass": "VK_SUBPASS_EXTERNAL",
-                "dstSubpass": 2345,
-                "srcStageMask": "VK_PIPELINE_STAGE_NONE_KHR",
-                "dstStageMask": "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "srcAccessMask": "VK_ACCESS_NONE_KHR",
-                "dstAccessMask": "VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT",
-                "dependencyFlags": "VK_DEPENDENCY_DEVICE_GROUP_BIT",
-                "viewOffset": 0
-            }
-        ],
-        "correlatedViewMaskCount": 1,
-        "pCorrelatedViewMasks": [ 8 ]
-    })"};
+    VkRenderPassCreateInfo2 ci;
+    auto [ref_ci, json] = getVkRenderPassCreateInfo2(0);
 
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &rp2_ci, &msg_));
-    const auto& adsl = *reinterpret_cast<const VkAttachmentDescriptionStencilLayout*>(rp2_ci.pAttachments[0].pNext);
-    const auto& fsrai = *reinterpret_cast<const VkFragmentShadingRateAttachmentInfoKHR*>(rp2_ci.pSubpasses[0].pNext);
-    const auto& sddsr = *reinterpret_cast<const VkSubpassDescriptionDepthStencilResolve*>(fsrai.pNext);
-    const auto& mb2 = *reinterpret_cast<const VkMemoryBarrier2KHR*>(rp2_ci.pDependencies[0].pNext);
-
-    EXPECT_EQ(rp2_ci.sType, VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2);
-    EXPECT_EQ(rp2_ci.pNext, nullptr);
-    EXPECT_EQ(rp2_ci.flags, 0);
-    EXPECT_EQ(rp2_ci.attachmentCount, 1);
-    EXPECT_EQ(rp2_ci.pAttachments[0].sType, VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2);
-    EXPECT_EQ(adsl.sType, VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT);
-    EXPECT_EQ(adsl.pNext, nullptr);
-    EXPECT_EQ(adsl.stencilInitialLayout, VK_IMAGE_LAYOUT_GENERAL);
-    EXPECT_EQ(adsl.stencilFinalLayout, VK_IMAGE_LAYOUT_GENERAL);
-    EXPECT_EQ(rp2_ci.pAttachments[0].flags, VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT);
-    EXPECT_EQ(rp2_ci.pAttachments[0].format, VK_FORMAT_R8G8_USCALED);
-    EXPECT_EQ(rp2_ci.pAttachments[0].samples, VK_SAMPLE_COUNT_8_BIT);
-    EXPECT_EQ(rp2_ci.pAttachments[0].loadOp, VK_ATTACHMENT_LOAD_OP_DONT_CARE);
-    EXPECT_EQ(rp2_ci.pAttachments[0].storeOp, VK_ATTACHMENT_STORE_OP_STORE);
-    EXPECT_EQ(rp2_ci.pAttachments[0].stencilLoadOp, VK_ATTACHMENT_LOAD_OP_LOAD);
-    EXPECT_EQ(rp2_ci.pAttachments[0].stencilStoreOp, VK_ATTACHMENT_STORE_OP_DONT_CARE);
-    EXPECT_EQ(rp2_ci.pAttachments[0].initialLayout, VK_IMAGE_LAYOUT_GENERAL);
-    EXPECT_EQ(rp2_ci.pAttachments[0].finalLayout, VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR);
-    EXPECT_EQ(rp2_ci.subpassCount, 2);
-    EXPECT_EQ(rp2_ci.pSubpasses[0].sType, VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2);
-    EXPECT_EQ(fsrai.sType, VK_STRUCTURE_TYPE_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR);
-    EXPECT_EQ(sddsr.sType, VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE);
-    EXPECT_EQ(sddsr.pNext, nullptr);
-    EXPECT_EQ(sddsr.depthResolveMode, VK_RESOLVE_MODE_MIN_BIT);
-    EXPECT_EQ(sddsr.stencilResolveMode, VK_RESOLVE_MODE_MAX_BIT);
-    EXPECT_EQ(sddsr.pDepthStencilResolveAttachment->sType, VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2);
-    EXPECT_EQ(sddsr.pDepthStencilResolveAttachment->pNext, nullptr);
-    EXPECT_EQ(sddsr.pDepthStencilResolveAttachment->attachment, 8);
-    EXPECT_EQ(sddsr.pDepthStencilResolveAttachment->layout, VK_IMAGE_LAYOUT_GENERAL);
-    EXPECT_EQ(sddsr.pDepthStencilResolveAttachment->aspectMask, VK_IMAGE_ASPECT_COLOR_BIT);
-    EXPECT_EQ(fsrai.pFragmentShadingRateAttachment->sType, VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2);
-    EXPECT_EQ(fsrai.pFragmentShadingRateAttachment->pNext, nullptr);
-    EXPECT_EQ(fsrai.pFragmentShadingRateAttachment->attachment, 5);
-    EXPECT_EQ(fsrai.pFragmentShadingRateAttachment->layout, VK_IMAGE_LAYOUT_GENERAL);
-    EXPECT_EQ(fsrai.pFragmentShadingRateAttachment->aspectMask, VK_IMAGE_ASPECT_COLOR_BIT);
-    EXPECT_EQ(fsrai.shadingRateAttachmentTexelSize.width, 4);
-    EXPECT_EQ(fsrai.shadingRateAttachmentTexelSize.height, 4);
-    EXPECT_EQ(rp2_ci.pSubpasses[0].flags, 0);
-    EXPECT_EQ(rp2_ci.pSubpasses[0].pipelineBindPoint, VK_PIPELINE_BIND_POINT_GRAPHICS);
-    EXPECT_EQ(rp2_ci.pSubpasses[0].inputAttachmentCount, 1);
-    EXPECT_EQ(rp2_ci.pSubpasses[0].pInputAttachments[0].attachment, 567);
-    EXPECT_EQ(rp2_ci.pSubpasses[0].pInputAttachments[0].layout, VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL);
-    EXPECT_EQ(rp2_ci.pSubpasses[0].colorAttachmentCount, 1);
-    EXPECT_EQ(rp2_ci.pSubpasses[0].pColorAttachments[0].attachment, VK_ATTACHMENT_UNUSED);
-    EXPECT_EQ(rp2_ci.pSubpasses[0].pColorAttachments[0].layout, VK_IMAGE_LAYOUT_UNDEFINED);
-    EXPECT_EQ(rp2_ci.pSubpasses[0].pResolveAttachments[0].attachment, VK_ATTACHMENT_UNUSED);
-    EXPECT_EQ(rp2_ci.pSubpasses[0].pResolveAttachments[0].layout, VK_IMAGE_LAYOUT_UNDEFINED);
-    EXPECT_EQ(rp2_ci.pSubpasses[0].pDepthStencilAttachment[0].attachment, VK_ATTACHMENT_UNUSED);
-    EXPECT_EQ(rp2_ci.pSubpasses[0].pDepthStencilAttachment[0].layout, VK_IMAGE_LAYOUT_UNDEFINED);
-    EXPECT_EQ(rp2_ci.pSubpasses[0].preserveAttachmentCount, 0);
-    EXPECT_EQ(rp2_ci.pSubpasses[0].pPreserveAttachments, nullptr);
-    EXPECT_EQ(rp2_ci.pSubpasses[1].sType, VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2);
-    EXPECT_EQ(rp2_ci.pSubpasses[1].pNext, nullptr);
-    EXPECT_EQ(rp2_ci.pSubpasses[1].flags, 0);
-    EXPECT_EQ(rp2_ci.pSubpasses[1].pipelineBindPoint, VK_PIPELINE_BIND_POINT_GRAPHICS);
-    EXPECT_EQ(rp2_ci.pSubpasses[1].inputAttachmentCount, 0);
-    EXPECT_EQ(rp2_ci.pSubpasses[1].pInputAttachments, nullptr);
-    EXPECT_EQ(rp2_ci.pSubpasses[1].colorAttachmentCount, 1);
-    EXPECT_EQ(rp2_ci.pSubpasses[1].pColorAttachments[0].attachment, 567);
-    EXPECT_EQ(rp2_ci.pSubpasses[1].pColorAttachments[0].layout, VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL_KHR);
-    EXPECT_EQ(rp2_ci.pSubpasses[1].pResolveAttachments[0].attachment, VK_ATTACHMENT_UNUSED);
-    EXPECT_EQ(rp2_ci.pSubpasses[1].pResolveAttachments[0].layout, VK_IMAGE_LAYOUT_UNDEFINED);
-    EXPECT_EQ(rp2_ci.pSubpasses[1].pDepthStencilAttachment[0].attachment, VK_ATTACHMENT_UNUSED);
-    EXPECT_EQ(rp2_ci.pSubpasses[1].pDepthStencilAttachment[0].layout, VK_IMAGE_LAYOUT_UNDEFINED);
-    EXPECT_EQ(rp2_ci.pSubpasses[1].preserveAttachmentCount, 0);
-    EXPECT_EQ(rp2_ci.pSubpasses[1].pPreserveAttachments, nullptr);
-    EXPECT_EQ(rp2_ci.dependencyCount, 1);
-    EXPECT_EQ(rp2_ci.pDependencies[0].sType, VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2);
-    EXPECT_EQ(mb2.sType, VK_STRUCTURE_TYPE_MEMORY_BARRIER_2_KHR);
-    EXPECT_EQ(mb2.pNext, nullptr);
-    EXPECT_EQ(mb2.srcStageMask, VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT);
-    EXPECT_EQ(mb2.srcAccessMask, VK_ACCESS_2_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT);
-    EXPECT_EQ(mb2.dstStageMask, VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT);
-    EXPECT_EQ(mb2.dstAccessMask, VK_ACCESS_2_COMMAND_PREPROCESS_READ_BIT_NV);
-    EXPECT_EQ(rp2_ci.pDependencies[0].srcSubpass, VK_SUBPASS_EXTERNAL);
-    EXPECT_EQ(rp2_ci.pDependencies[0].dstSubpass, 2345);
-    EXPECT_EQ(rp2_ci.pDependencies[0].srcStageMask, VK_PIPELINE_STAGE_NONE_KHR);
-    EXPECT_EQ(rp2_ci.pDependencies[0].dstStageMask, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
-    EXPECT_EQ(rp2_ci.pDependencies[0].srcAccessMask, VK_ACCESS_NONE_KHR);
-    EXPECT_EQ(rp2_ci.pDependencies[0].dstAccessMask, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
-    EXPECT_EQ(rp2_ci.pDependencies[0].dependencyFlags, VK_DEPENDENCY_DEVICE_GROUP_BIT);
-    EXPECT_EQ(rp2_ci.correlatedViewMaskCount, 1);
-    EXPECT_EQ(rp2_ci.pCorrelatedViewMasks[0], 8);
+    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &ci, &msg_));
+    CompareStruct(ref_ci, ci);
 }
 
 TEST_F(Parse, VkShaderModuleCreateInfo) {
@@ -1662,1493 +468,244 @@ TEST_F(Parse, VkPipelineOfflineCreateInfo) {
 TEST_F(Parse, ComputePipelineJSON) {
     TEST_DESCRIPTION("Tests parsing of a reasonably simple compute pipeline JSON");
 
-    const std::string json{R"({
-    "ComputePipelineState" : 
-    {
-        "ComputePipeline" : 
-        {
-            "basePipelineHandle" : "",
-            "basePipelineIndex" : 0,
-            "flags" : 0,
-            "layout" : "",
-            "pNext" : "NULL",
-            "sType" : "VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO",
-            "stage" : 
-            {
-                "flags" : "VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT",
-                "module" : "",
-                "pName" : "main",
-                "pNext" : 
-                {
-                    "pNext" : "NULL",
-                    "requiredSubgroupSize" : 64,
-                    "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO"
-                },
-                "pSpecializationInfo" : "NULL",
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                "stage" : "VK_SHADER_STAGE_COMPUTE_BIT"
-            }
-        },
-)"
-                           R"(
-        "DescriptorSetLayouts" : 
-        [
-            {
-                "DescriptorSetLayout1" : 
-                {
-                    "bindingCount" : 3,
-                    "flags" : "VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT",
-                    "pBindings" : 
-                    [
-                        {
-                            "binding" : 0,
-                            "descriptorCount" : 1,
-                            "descriptorType" : "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
-                            "pImmutableSamplers" : "NULL",
-                            "stageFlags" : "VK_SHADER_STAGE_COMPUTE_BIT"
-                        },
-                        {
-                            "binding" : 1,
-                            "descriptorCount" : 1,
-                            "descriptorType" : "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
-                            "pImmutableSamplers" : 
-                            [
-                                "ImmutableSampler1"
-                            ],
-                            "stageFlags" : "VK_SHADER_STAGE_COMPUTE_BIT"
-                        },
-                        {
-                            "binding" : 2,
-                            "descriptorCount" : 1,
-                            "descriptorType" : "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
-                            "pImmutableSamplers" : 
-                            [
-                                "YcbcrSampler1"
-                            ],
-                            "stageFlags" : "VK_SHADER_STAGE_COMPUTE_BIT"
-                        }
-                    ],
-                    "pNext" : 
-                    {
-                        "bindingCount" : 1,
-                        "pBindingFlags" : 
-                        [
-                            "VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT"
-                        ],
-                        "pNext" : "NULL",
-                        "sType" : "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO"
-                    },
-                    "sType" : "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO"
-                }
-            }
-        ],
-)"
-                           R"(
-        "ImmutableSamplers" : 
-        [
-            {
-                "ImmutableSampler1" : 
-                {
-                    "addressModeU" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "addressModeV" : "VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT",
-                    "addressModeW" : "VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE",
-                    "anisotropyEnable" : "VK_FALSE",
-                    "borderColor" : "VK_BORDER_COLOR_FLOAT_CUSTOM_EXT",
-                    "compareEnable" : "VK_FALSE",
-                    "compareOp" : "VK_COMPARE_OP_NEVER",
-                    "flags" : 0,
-                    "magFilter" : "VK_FILTER_CUBIC_EXT",
-                    "maxAnisotropy" : 2.0,
-                    "maxLod" : 1000.0,
-                    "minFilter" : "VK_FILTER_NEAREST",
-                    "minLod" : 0.5,
-                    "mipLodBias" : 0.5,
-                    "mipmapMode" : "VK_SAMPLER_MIPMAP_MODE_LINEAR",
-                    "pNext" : 
-                    {
-                        "pNext" : "NULL",
-                        "reductionMode" : "VK_SAMPLER_REDUCTION_MODE_MAX",
-                        "sType" : "VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO"
-                    },
-                    "sType" : "VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO",
-                    "unnormalizedCoordinates" : "VK_TRUE"
-                }
-            },
-            {
-                "YcbcrSampler1" : 
-                {
-                    "addressModeU" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "addressModeV" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "addressModeW" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "anisotropyEnable" : "VK_FALSE",
-                    "borderColor" : "VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK",
-                    "compareEnable" : "VK_FALSE",
-                    "compareOp" : "VK_COMPARE_OP_NEVER",
-                    "flags" : 0,
-                    "magFilter" : "VK_FILTER_NEAREST",
-                    "maxAnisotropy" : 0.0,
-                    "maxLod" : 0.0,
-                    "minFilter" : "VK_FILTER_NEAREST",
-                    "minLod" : 0.0,
-                    "mipLodBias" : 0.0,
-                    "mipmapMode" : "VK_SAMPLER_MIPMAP_MODE_NEAREST",
-                    "pNext" : 
-                    {
-                        "conversion" : "YcbcrConversion1",
-                        "pNext" : "NULL",
-                        "sType" : "VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO"
-                    },
-                    "sType" : "VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO",
-                    "unnormalizedCoordinates" : "VK_FALSE"
-                }
-            }
-        ],
-)"
-                           R"(
-        "PhysicalDeviceFeatures" : 
-        {
-            "features" : 
-            {
-                "alphaToOne" : "VK_FALSE",
-                "depthBiasClamp" : "VK_FALSE",
-                "depthBounds" : "VK_FALSE",
-                "depthClamp" : "VK_FALSE",
-                "drawIndirectFirstInstance" : "VK_FALSE",
-                "dualSrcBlend" : "VK_FALSE",
-                "fillModeNonSolid" : "VK_FALSE",
-                "fragmentStoresAndAtomics" : "VK_FALSE",
-                "fullDrawIndexUint32" : "VK_FALSE",
-                "geometryShader" : "VK_FALSE",
-                "imageCubeArray" : "VK_FALSE",
-                "independentBlend" : "VK_FALSE",
-                "inheritedQueries" : "VK_FALSE",
-                "largePoints" : "VK_FALSE",
-                "logicOp" : "VK_FALSE",
-                "multiDrawIndirect" : "VK_FALSE",
-                "multiViewport" : "VK_FALSE",
-                "occlusionQueryPrecise" : "VK_FALSE",
-                "pipelineStatisticsQuery" : "VK_FALSE",
-                "robustBufferAccess" : "VK_TRUE",
-                "sampleRateShading" : "VK_FALSE",
-                "samplerAnisotropy" : "VK_FALSE",
-                "shaderClipDistance" : "VK_FALSE",
-                "shaderCullDistance" : "VK_FALSE",
-                "shaderFloat64" : "VK_FALSE",
-                "shaderImageGatherExtended" : "VK_FALSE",
-                "shaderInt16" : "VK_FALSE",
-                "shaderInt64" : "VK_FALSE",
-                "shaderResourceMinLod" : "VK_FALSE",
-                "shaderResourceResidency" : "VK_FALSE",
-                "shaderSampledImageArrayDynamicIndexing" : "VK_FALSE",
-                "shaderStorageBufferArrayDynamicIndexing" : "VK_FALSE",
-                "shaderStorageImageArrayDynamicIndexing" : "VK_FALSE",
-                "shaderStorageImageExtendedFormats" : "VK_FALSE",
-                "shaderStorageImageMultisample" : "VK_FALSE",
-                "shaderStorageImageReadWithoutFormat" : "VK_FALSE",
-                "shaderStorageImageWriteWithoutFormat" : "VK_FALSE",
-                "shaderTessellationAndGeometryPointSize" : "VK_FALSE",
-                "shaderUniformBufferArrayDynamicIndexing" : "VK_FALSE",
-                "sparseBinding" : "VK_FALSE",
-                "sparseResidency16Samples" : "VK_FALSE",
-                "sparseResidency2Samples" : "VK_FALSE",
-                "sparseResidency4Samples" : "VK_FALSE",
-                "sparseResidency8Samples" : "VK_FALSE",
-                "sparseResidencyAliased" : "VK_FALSE",
-                "sparseResidencyBuffer" : "VK_FALSE",
-                "sparseResidencyImage2D" : "VK_FALSE",
-                "sparseResidencyImage3D" : "VK_FALSE",
-                "tessellationShader" : "VK_FALSE",
-                "textureCompressionASTC_LDR" : "VK_FALSE",
-                "textureCompressionBC" : "VK_FALSE",
-                "textureCompressionETC2" : "VK_FALSE",
-                "variableMultisampleRate" : "VK_FALSE",
-                "vertexPipelineStoresAndAtomics" : "VK_FALSE",
-                "wideLines" : "VK_FALSE"
-            },
-            "pNext" : 
-            {
-                "pNext" : "NULL",
-                "sType" : "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES",
-                "synchronization2" : "VK_TRUE"
-            },
-            "sType" : "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2"
-        },
-)"
-                           R"(
-        "PipelineLayout" : 
-        {
-            "flags" : 0,
-            "pNext" : "NULL",
-            "pPushConstantRanges" : 
-            [
-                {
-                    "offset" : 0,
-                    "size" : 4,
-                    "stageFlags" : "VK_SHADER_STAGE_COMPUTE_BIT"
-                }
-            ],
-            "pSetLayouts" : 
-            [
-                "DescriptorSetLayout1"
-            ],
-            "pushConstantRangeCount" : 1,
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO",
-            "setLayoutCount" : 1
-        },
-        "ShaderFileNames" : 
-        [
-            {
-                "filename" : "shader.comp.spv",
-                "stage" : "VK_SHADER_STAGE_COMPUTE_BIT"
-            }
-        ],
-        "YcbcrSamplers" : 
-        [
-            {
-                "YcbcrConversion1" : 
-                {
-                    "chromaFilter" : "VK_FILTER_CUBIC_EXT",
-                    "components" : 
-                    {
-                        "a" : "VK_COMPONENT_SWIZZLE_R",
-                        "b" : "VK_COMPONENT_SWIZZLE_G",
-                        "g" : "VK_COMPONENT_SWIZZLE_B",
-                        "r" : "VK_COMPONENT_SWIZZLE_A"
-                    },
-                    "forceExplicitReconstruction" : "VK_TRUE",
-                    "format" : "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16",
-                    "pNext" : "NULL",
-                    "sType" : "VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO",
-                    "xChromaOffset" : "VK_CHROMA_LOCATION_COSITED_EVEN",
-                    "yChromaOffset" : "VK_CHROMA_LOCATION_MIDPOINT",
-                    "ycbcrModel" : "VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020",
-                    "ycbcrRange" : "VK_SAMPLER_YCBCR_RANGE_ITU_NARROW"
-                }
-            }
-        ]
-    },
-    "EnabledExtensions" : 
-    [
-        "VK_EXT_robustness2"
-    ],
-    "PipelineUUID" : 
-    [
-        85,
-        43,
-        255,
-        24,
-        155,
-        64,
-        62,
-        24,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0
-    ]
-})"};
-    EXPECT_TRUE(ValidatePipelineJson(json));
+    VpjData data{};
 
-    VpjData data;
+    const char* ycbcr_names[1] = {"YcbcrConversion1"};
+    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
+    auto ycbcr_conversion = VkSamplerYcbcrConversion(100);
+
+    const char* sampler_names[2] = {"ImmutableSampler1", "YcbcrSampler1"};
+    auto [immut_sampler_ci, immut_sampler_json] =
+        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerReductionModeCreateInfo(VK_SAMPLER_REDUCTION_MODE_MAX)));
+    auto [ycbcr_sampler_ci, ycbcr_sampler_json] =
+        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerYcbcrConversionInfo(ycbcr_conversion, ycbcr_names[0])));
+    VkSamplerCreateInfo sampler_ci[2] = {*immut_sampler_ci.ptr(), *ycbcr_sampler_ci.ptr()};
+    VkSampler immutableSamplers[2] = {VkSampler(100), VkSampler(101)};
+
+    const char* dsl_names[1] = {"DescriptorSetLayout1"};
+    auto [dsl_ci, dsl_json] =
+        getVkDescriptorSetLayoutCreateInfo(0,
+                                           {{1, VK_SHADER_STAGE_COMPUTE_BIT},
+                                            {1, VK_SHADER_STAGE_COMPUTE_BIT, immutableSamplers[0], sampler_names[0]},
+                                            {1, VK_SHADER_STAGE_COMPUTE_BIT, immutableSamplers[1], sampler_names[1]}},
+                                           std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
+
+    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(100), dsl_names[0]}});
+
+    auto [cp_ci, cp_json] = getVkComputePipelineCreateInfo(getVkPipelineShaderStageCreateInfo(
+        0, VK_SHADER_STAGE_COMPUTE_BIT, std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo())));
+
+    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0, std::make_tuple(getVkPhysicalDeviceSynchronization2Features()));
+
+    auto [shaderFileNames, shaderFileNames_json] = getShaderFileNames({{VK_SHADER_STAGE_COMPUTE_BIT, "shader.comp.spv"}});
+
+    const char* enabled_extensions[1] = {"VK_EXT_robustness2"};
+
+    const std::string json = R"({
+        "ComputePipelineState" :
+        {
+            "ComputePipeline" : )" +
+                             cp_json +
+                             R"(,
+            "DescriptorSetLayouts" :
+            [
+                {
+                    ")" + dsl_names[0] +
+                             R"(" : )" + dsl_json + R"(
+                }
+            ],
+            "ImmutableSamplers" :
+            [
+                {
+                    ")" + sampler_names[0] +
+                             R"(" : )" + immut_sampler_json + R"(
+                },
+                {
+                    ")" + sampler_names[1] +
+                             R"(" : )" + ycbcr_sampler_json + R"(
+                }
+            ],
+            "PhysicalDeviceFeatures" : )" +
+                             pdf_json + R"(,
+            "PipelineLayout" : )" +
+                             pl_json +
+                             R"(,
+            "ShaderFileNames" : )" +
+                             shaderFileNames_json +
+                             R"(,
+            "YcbcrSamplers" :
+            [
+                {
+                    ")" + ycbcr_names[0] +
+                             R"(" : )" + ycbcr_json + R"(
+                }
+            ]
+        },
+        "EnabledExtensions" :
+        [
+            "VK_EXT_robustness2"
+        ],
+        "PipelineUUID" : [85, 43, 255, 24, 155, 64, 62, 24, 0, 0, 0, 0, 0, 0, 0, 0]
+    })";
+
+    VpjData ref_data{};
+    ref_data.enabledExtensionCount = 1;
+    ref_data.ppEnabledExtensions = enabled_extensions;
+    ref_data.computePipelineState.pComputePipeline = &cp_ci;
+    ref_data.computePipelineState.pPipelineLayout = &pl_ci;
+    ref_data.computePipelineState.immutableSamplerCount = 2;
+    ref_data.computePipelineState.ppImmutableSamplerNames = sampler_names;
+    ref_data.computePipelineState.pImmutableSamplers = sampler_ci;
+    ref_data.computePipelineState.ycbcrSamplerCount = 1;
+    ref_data.computePipelineState.ppYcbcrSamplerNames = ycbcr_names;
+    ref_data.computePipelineState.pYcbcrSamplers = &ycbcr_ci;
+    ref_data.computePipelineState.descriptorSetLayoutCount = 1;
+    ref_data.computePipelineState.pDescriptorSetLayouts = &dsl_ci;
+    ref_data.computePipelineState.ppDescriptorSetLayoutNames = dsl_names;
+    ref_data.computePipelineState.pPhysicalDeviceFeatures = &pdf;
+    ref_data.computePipelineState.shaderFileNameCount = (uint32_t)shaderFileNames.size();
+    ref_data.computePipelineState.pShaderFileNames = shaderFileNames.data();
+
+    ref_data.pipelineUUID[0] = 85;
+    ref_data.pipelineUUID[1] = 43;
+    ref_data.pipelineUUID[2] = 255;
+    ref_data.pipelineUUID[3] = 24;
+    ref_data.pipelineUUID[4] = 155;
+    ref_data.pipelineUUID[5] = 64;
+    ref_data.pipelineUUID[6] = 62;
+    ref_data.pipelineUUID[7] = 24;
+
     EXPECT_TRUE(vpjParsePipelineJson(this->parser_, json.c_str(), &data, &msg_));
     CHECK_PARSE(true);
-    const auto& dsl_ci =
-        reinterpret_cast<const VkDescriptorSetLayoutCreateInfo*>(data.computePipelineState.pDescriptorSetLayouts)[0];
-    const auto& dsl_names = data.computePipelineState.ppDescriptorSetLayoutNames;
-    const auto& bf_ci = *reinterpret_cast<const VkDescriptorSetLayoutBindingFlagsCreateInfo*>(dsl_ci.pNext);
-    const auto& pl_ci = *reinterpret_cast<const VkPipelineLayoutCreateInfo*>(data.computePipelineState.pPipelineLayout);
-    const auto& cp_ci = *reinterpret_cast<const VkComputePipelineCreateInfo*>(data.computePipelineState.pComputePipeline);
-    const auto& pssrss_ci = *reinterpret_cast<const VkPipelineShaderStageRequiredSubgroupSizeCreateInfo*>(cp_ci.stage.pNext);
-    const auto& sfn = data.computePipelineState.pShaderFileNames;
-    const auto& pdf = *reinterpret_cast<const VkPhysicalDeviceFeatures2*>(data.computePipelineState.pPhysicalDeviceFeatures);
-    const auto& pdfsync2 = *reinterpret_cast<const VkPhysicalDeviceSynchronization2Features*>(pdf.pNext);
-    const auto& sampler_cis = reinterpret_cast<const VkSamplerCreateInfo*>(data.computePipelineState.pImmutableSamplers);
-    const auto& sampler_names = data.computePipelineState.ppImmutableSamplerNames;
-    const auto& srm_ci = *reinterpret_cast<const VkSamplerReductionModeCreateInfo*>(sampler_cis[0].pNext);
-    const auto& ycbcrci = *reinterpret_cast<const VkSamplerYcbcrConversionInfo*>(sampler_cis[1].pNext);
-    const auto& ycbcr_names = data.computePipelineState.ppYcbcrSamplerNames;
-    const auto& ycbcr_ci = reinterpret_cast<const VkSamplerYcbcrConversionCreateInfo*>(data.computePipelineState.pYcbcrSamplers)[0];
 
-    EXPECT_EQ(data.computePipelineState.descriptorSetLayoutCount, 1);
-    EXPECT_STREQ(dsl_names[0], "DescriptorSetLayout1");
-    EXPECT_EQ(dsl_ci.sType, VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO);
-    EXPECT_EQ(bf_ci.sType, VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO);
-    EXPECT_EQ(bf_ci.pNext, nullptr);
-    EXPECT_EQ(bf_ci.bindingCount, 1);
-    EXPECT_EQ(bf_ci.pBindingFlags[0], VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT);
-    EXPECT_EQ(dsl_ci.flags, VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT);
-    EXPECT_EQ(dsl_ci.bindingCount, 3);
-    EXPECT_EQ(dsl_ci.pBindings[0].binding, 0);
-    EXPECT_EQ(dsl_ci.pBindings[0].descriptorType, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-    EXPECT_EQ(dsl_ci.pBindings[0].descriptorCount, 1);
-    EXPECT_EQ(dsl_ci.pBindings[0].stageFlags, VK_SHADER_STAGE_COMPUTE_BIT);
-    EXPECT_EQ(dsl_ci.pBindings[0].pImmutableSamplers, nullptr);
-    EXPECT_EQ(dsl_ci.pBindings[1].binding, 1);
-    EXPECT_EQ(dsl_ci.pBindings[1].descriptorType, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
-    EXPECT_EQ((uintptr_t)dsl_ci.pBindings[1].pImmutableSamplers[0], 0);
-    EXPECT_EQ(dsl_ci.pBindings[1].descriptorCount, 1);
-    EXPECT_EQ(dsl_ci.pBindings[1].stageFlags, VK_SHADER_STAGE_COMPUTE_BIT);
-    EXPECT_EQ(dsl_ci.pBindings[2].binding, 2);
-    EXPECT_EQ(dsl_ci.pBindings[2].descriptorType, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
-    EXPECT_EQ((uintptr_t)dsl_ci.pBindings[2].pImmutableSamplers[0], 1);
-    EXPECT_EQ(dsl_ci.pBindings[2].descriptorCount, 1);
-    EXPECT_EQ(dsl_ci.pBindings[2].stageFlags, VK_SHADER_STAGE_COMPUTE_BIT);
-    EXPECT_EQ(data.computePipelineState.immutableSamplerCount, 2);
-    EXPECT_STREQ(sampler_names[0], "ImmutableSampler1");
-    EXPECT_STREQ(sampler_names[1], "YcbcrSampler1");
-    EXPECT_EQ(sampler_cis[0].sType, VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO);
-    EXPECT_EQ(srm_ci.sType, VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO);
-    EXPECT_EQ(srm_ci.pNext, nullptr);
-    EXPECT_EQ(srm_ci.reductionMode, VK_SAMPLER_REDUCTION_MODE_MAX);
-    EXPECT_EQ(sampler_cis[0].addressModeU, VK_SAMPLER_ADDRESS_MODE_REPEAT);
-    EXPECT_EQ(sampler_cis[0].addressModeV, VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT);
-    EXPECT_EQ(sampler_cis[0].addressModeW, VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE);
-    EXPECT_EQ(sampler_cis[0].anisotropyEnable, VK_FALSE);
-    EXPECT_EQ(sampler_cis[0].borderColor, VK_BORDER_COLOR_FLOAT_CUSTOM_EXT);
-    EXPECT_EQ(sampler_cis[0].compareEnable, VK_FALSE);
-    EXPECT_EQ(sampler_cis[0].compareOp, VK_COMPARE_OP_NEVER);
-    EXPECT_EQ(sampler_cis[0].flags, 0);
-    EXPECT_EQ(sampler_cis[0].magFilter, VK_FILTER_CUBIC_EXT);
-    EXPECT_EQ(sampler_cis[0].maxAnisotropy, 2.0);
-    EXPECT_EQ(sampler_cis[0].maxLod, 1000.0);
-    EXPECT_EQ(sampler_cis[0].minFilter, VK_FILTER_NEAREST);
-    EXPECT_EQ(sampler_cis[0].minLod, 0.5);
-    EXPECT_EQ(sampler_cis[0].mipLodBias, 0.5);
-    EXPECT_EQ(sampler_cis[0].mipmapMode, VK_SAMPLER_MIPMAP_MODE_LINEAR);
-    EXPECT_EQ(sampler_cis[0].unnormalizedCoordinates, VK_TRUE);
-    EXPECT_EQ(sampler_cis[1].sType, VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO);
-    EXPECT_EQ(ycbcrci.sType, VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO);
-    EXPECT_EQ(ycbcrci.pNext, nullptr);
-    EXPECT_EQ((uintptr_t)ycbcrci.conversion, 0);
-    EXPECT_EQ(sampler_cis[1].addressModeU, VK_SAMPLER_ADDRESS_MODE_REPEAT);
-    EXPECT_EQ(sampler_cis[1].addressModeV, VK_SAMPLER_ADDRESS_MODE_REPEAT);
-    EXPECT_EQ(sampler_cis[1].addressModeW, VK_SAMPLER_ADDRESS_MODE_REPEAT);
-    EXPECT_EQ(sampler_cis[1].anisotropyEnable, VK_FALSE);
-    EXPECT_EQ(sampler_cis[1].borderColor, VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK);
-    EXPECT_EQ(sampler_cis[1].compareEnable, VK_FALSE);
-    EXPECT_EQ(sampler_cis[1].compareOp, VK_COMPARE_OP_NEVER);
-    EXPECT_EQ(sampler_cis[1].flags, 0);
-    EXPECT_EQ(sampler_cis[1].magFilter, VK_FILTER_NEAREST);
-    EXPECT_EQ(sampler_cis[1].maxAnisotropy, 0.0);
-    EXPECT_EQ(sampler_cis[1].maxLod, 0.0);
-    EXPECT_EQ(sampler_cis[1].minFilter, VK_FILTER_NEAREST);
-    EXPECT_EQ(sampler_cis[1].minLod, 0.0);
-    EXPECT_EQ(sampler_cis[1].mipLodBias, 0.0);
-    EXPECT_EQ(sampler_cis[1].mipmapMode, VK_SAMPLER_MIPMAP_MODE_NEAREST);
-    EXPECT_EQ(sampler_cis[1].unnormalizedCoordinates, VK_FALSE);
-    EXPECT_EQ(pl_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO);
-    EXPECT_EQ(pl_ci.pNext, nullptr);
-    EXPECT_EQ(pl_ci.flags, 0);
-    EXPECT_EQ(pl_ci.setLayoutCount, 1);
-    EXPECT_EQ(pl_ci.pSetLayouts[0], reinterpret_cast<void*>(0));
-    EXPECT_EQ(pl_ci.pushConstantRangeCount, 1);
-    EXPECT_EQ(pl_ci.pPushConstantRanges[0].stageFlags, VK_SHADER_STAGE_COMPUTE_BIT);
-    EXPECT_EQ(pl_ci.pPushConstantRanges[0].offset, 0);
-    EXPECT_EQ(pl_ci.pPushConstantRanges[0].size, 4);
-    EXPECT_EQ(cp_ci.sType, VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO);
-    EXPECT_EQ(cp_ci.flags, 0);
-    EXPECT_EQ(cp_ci.stage.sType, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO);
-    EXPECT_EQ(pssrss_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO);
-    EXPECT_EQ(pssrss_ci.pNext, nullptr);
-    EXPECT_EQ(pssrss_ci.requiredSubgroupSize, 64);
-    EXPECT_EQ(cp_ci.stage.flags, VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT);
-    EXPECT_EQ(cp_ci.stage.stage, VK_SHADER_STAGE_COMPUTE_BIT);
-    EXPECT_STREQ(cp_ci.stage.pName, "main");
-    EXPECT_EQ(cp_ci.stage.pSpecializationInfo, nullptr);
-    EXPECT_EQ(cp_ci.stage.module, VK_NULL_HANDLE);
-    // cp_ci.layout can't be meaningfully reconstructed
-    EXPECT_EQ(cp_ci.basePipelineHandle, VK_NULL_HANDLE);
-    EXPECT_EQ(cp_ci.basePipelineIndex, 0);
-    EXPECT_EQ(sfn[0].stage, VK_SHADER_STAGE_COMPUTE_BIT);
-    EXPECT_STREQ(sfn[0].pFilename, "shader.comp.spv");
-    EXPECT_EQ(data.computePipelineState.ycbcrSamplerCount, 1);
-    EXPECT_STREQ(ycbcr_names[0], "YcbcrConversion1");
-    EXPECT_EQ(ycbcr_ci.sType, VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO);
-    EXPECT_EQ(ycbcr_ci.pNext, nullptr);
-    EXPECT_EQ(ycbcr_ci.chromaFilter, VK_FILTER_CUBIC_EXT);
-    EXPECT_EQ(ycbcr_ci.components.a, VK_COMPONENT_SWIZZLE_R);
-    EXPECT_EQ(ycbcr_ci.components.b, VK_COMPONENT_SWIZZLE_G);
-    EXPECT_EQ(ycbcr_ci.components.g, VK_COMPONENT_SWIZZLE_B);
-    EXPECT_EQ(ycbcr_ci.components.r, VK_COMPONENT_SWIZZLE_A);
-    EXPECT_EQ(ycbcr_ci.forceExplicitReconstruction, VK_TRUE);
-    EXPECT_EQ(ycbcr_ci.format, VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16);
-    EXPECT_EQ(ycbcr_ci.xChromaOffset, VK_CHROMA_LOCATION_COSITED_EVEN);
-    EXPECT_EQ(ycbcr_ci.yChromaOffset, VK_CHROMA_LOCATION_MIDPOINT);
-    EXPECT_EQ(ycbcr_ci.ycbcrModel, VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020);
-    EXPECT_EQ(ycbcr_ci.ycbcrRange, VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
-    EXPECT_EQ(pdf.sType, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2);
-    EXPECT_EQ(pdfsync2.sType, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES);
-    EXPECT_EQ(pdfsync2.pNext, nullptr);
-    EXPECT_EQ(pdfsync2.synchronization2, VK_TRUE);
-    EXPECT_EQ(pdf.features.robustBufferAccess, VK_TRUE);
-    EXPECT_EQ(pdf.features.fullDrawIndexUint32, VK_FALSE);
-    EXPECT_EQ(pdf.features.imageCubeArray, VK_FALSE);
-    EXPECT_EQ(pdf.features.independentBlend, VK_FALSE);
-    EXPECT_EQ(pdf.features.geometryShader, VK_FALSE);
-    EXPECT_EQ(pdf.features.tessellationShader, VK_FALSE);
-    EXPECT_EQ(pdf.features.sampleRateShading, VK_FALSE);
-    EXPECT_EQ(pdf.features.dualSrcBlend, VK_FALSE);
-    EXPECT_EQ(pdf.features.logicOp, VK_FALSE);
-    EXPECT_EQ(pdf.features.multiDrawIndirect, VK_FALSE);
-    EXPECT_EQ(pdf.features.drawIndirectFirstInstance, VK_FALSE);
-    EXPECT_EQ(pdf.features.depthClamp, VK_FALSE);
-    EXPECT_EQ(pdf.features.depthBiasClamp, VK_FALSE);
-    EXPECT_EQ(pdf.features.fillModeNonSolid, VK_FALSE);
-    EXPECT_EQ(pdf.features.depthBounds, VK_FALSE);
-    EXPECT_EQ(pdf.features.wideLines, VK_FALSE);
-    EXPECT_EQ(pdf.features.largePoints, VK_FALSE);
-    EXPECT_EQ(pdf.features.alphaToOne, VK_FALSE);
-    EXPECT_EQ(pdf.features.multiViewport, VK_FALSE);
-    EXPECT_EQ(pdf.features.samplerAnisotropy, VK_FALSE);
-    EXPECT_EQ(pdf.features.textureCompressionETC2, VK_FALSE);
-    EXPECT_EQ(pdf.features.textureCompressionASTC_LDR, VK_FALSE);
-    EXPECT_EQ(pdf.features.textureCompressionBC, VK_FALSE);
-    EXPECT_EQ(pdf.features.occlusionQueryPrecise, VK_FALSE);
-    EXPECT_EQ(pdf.features.pipelineStatisticsQuery, VK_FALSE);
-    EXPECT_EQ(pdf.features.vertexPipelineStoresAndAtomics, VK_FALSE);
-    EXPECT_EQ(pdf.features.fragmentStoresAndAtomics, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderTessellationAndGeometryPointSize, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderImageGatherExtended, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderStorageImageExtendedFormats, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderStorageImageMultisample, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderStorageImageReadWithoutFormat, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderStorageImageWriteWithoutFormat, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderUniformBufferArrayDynamicIndexing, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderSampledImageArrayDynamicIndexing, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderStorageBufferArrayDynamicIndexing, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderStorageImageArrayDynamicIndexing, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderClipDistance, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderCullDistance, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderFloat64, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderInt64, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderInt16, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderResourceResidency, VK_FALSE);
-    EXPECT_EQ(pdf.features.shaderResourceMinLod, VK_FALSE);
-    EXPECT_EQ(pdf.features.sparseBinding, VK_FALSE);
-    EXPECT_EQ(pdf.features.sparseResidencyBuffer, VK_FALSE);
-    EXPECT_EQ(pdf.features.sparseResidencyImage2D, VK_FALSE);
-    EXPECT_EQ(pdf.features.sparseResidencyImage3D, VK_FALSE);
-    EXPECT_EQ(pdf.features.sparseResidency2Samples, VK_FALSE);
-    EXPECT_EQ(pdf.features.sparseResidency4Samples, VK_FALSE);
-    EXPECT_EQ(pdf.features.sparseResidency8Samples, VK_FALSE);
-    EXPECT_EQ(pdf.features.sparseResidency16Samples, VK_FALSE);
-    EXPECT_EQ(pdf.features.sparseResidencyAliased, VK_FALSE);
-    EXPECT_EQ(pdf.features.variableMultisampleRate, VK_FALSE);
-    EXPECT_EQ(pdf.features.inheritedQueries, VK_FALSE);
-    EXPECT_EQ(data.enabledExtensionCount, 1);
-    EXPECT_STREQ(data.ppEnabledExtensions[0], "VK_EXT_robustness2");
-    uint8_t expected_uuid[VK_UUID_SIZE] = {85, 43, 255, 24, 155, 64, 62, 24, 0, 0, 0, 0, 0, 0, 0, 0};
-    EXPECT_UUIDEQ(data.pipelineUUID, expected_uuid);
+    CompareData<VpjComputePipelineState>(ref_data, data);
 }
 
 TEST_F(Parse, GraphicsPipelineJSON) {
     TEST_DESCRIPTION("Tests parsing of a reasonably simple graphics pipeline JSON");
 
-#ifdef VK_USE_PLATFORM_SCREEN_QNX
-    std::string ycbcr_ci_pnext = R"({
-            "sType" : "VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_QNX",
-            "pNext": "NULL",
-            "externalFormat": 10
+    VpjData data{};
+
+    const char* ycbcr_names[1] = {"YcbcrConversion1"};
+    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
+    auto ycbcr_conversion = VkSamplerYcbcrConversion(0);
+
+    const char* sampler_names[2] = {"ImmutableSampler1", "YcbcrSampler1"};
+    auto [immut_sampler_ci, immut_sampler_json] =
+        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerReductionModeCreateInfo(VK_SAMPLER_REDUCTION_MODE_MAX)));
+    auto [ycbcr_sampler_ci, ycbcr_sampler_json] =
+        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerYcbcrConversionInfo(ycbcr_conversion, ycbcr_names[0])));
+    VkSamplerCreateInfo sampler_ci[2] = {*immut_sampler_ci.ptr(), *ycbcr_sampler_ci.ptr()};
+    VkSampler immutableSamplers[2] = {VkSampler(0), VkSampler(1)};
+
+    const char* dsl_names[1] = {"DescriptorSetLayout1"};
+    auto [dsl_ci, dsl_json] =
+        getVkDescriptorSetLayoutCreateInfo(0,
+                                           {{1, VK_SHADER_STAGE_VERTEX_BIT},
+                                            {1, VK_SHADER_STAGE_FRAGMENT_BIT, immutableSamplers[0], sampler_names[0]},
+                                            {1, VK_SHADER_STAGE_FRAGMENT_BIT, immutableSamplers[1], sampler_names[1]}},
+                                           std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
+
+    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(0), dsl_names[0]}});
+
+    auto [renderPass, renderPass_json] = getVkRenderPassCreateInfo(0);
+
+    auto [gp_ci, gp_json] = getVkGraphicsPipelineCreateInfo(
+        0, {getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_VERTEX_BIT),
+            getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_FRAGMENT_BIT,
+                                               std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo()))});
+
+    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0, std::make_tuple(getVkPhysicalDeviceSynchronization2Features()));
+
+    auto [shaderFileNames, shaderFileNames_json] = getShaderFileNames({
+        {VK_SHADER_STAGE_VERTEX_BIT, "shader.vert.spv"},
+        {VK_SHADER_STAGE_FRAGMENT_BIT, "shader.frag.spv"},
+    });
+
+    const char* enabled_extensions[1] = {"VK_EXT_robustness2"};
+
+    const std::string json = R"({
+        "GraphicsPipelineState" :
+        {
+            "Renderpass": )" +
+                             renderPass_json +
+                             R"(,
+            "GraphicsPipeline" : )" +
+                             gp_json +
+                             R"(,
+            "DescriptorSetLayouts" :
+            [
+                {
+                    ")" + dsl_names[0] +
+                             R"(" : )" + dsl_json + R"(
+                }
+            ],
+            "ImmutableSamplers" :
+            [
+                {
+                    ")" + sampler_names[0] +
+                             R"(" : )" + immut_sampler_json + R"(
+                },
+                {
+                    ")" + sampler_names[1] +
+                             R"(" : )" + ycbcr_sampler_json + R"(
+                }
+            ],
+            "PhysicalDeviceFeatures" : )" +
+                             pdf_json + R"(,
+            "PipelineLayout" : )" +
+                             pl_json +
+                             R"(,
+            "ShaderFileNames" : )" +
+                             shaderFileNames_json +
+                             R"(,
+            "YcbcrSamplers" :
+            [
+                {
+                    ")" + ycbcr_names[0] +
+                             R"(" : )" + ycbcr_json + R"(
+                }
+            ]
+        },
+        "EnabledExtensions" :
+        [
+            "VK_EXT_robustness2"
+        ],
+        "PipelineUUID" : [85, 43, 255, 24, 155, 64, 62, 24, 0, 0, 0, 0, 0, 0, 0, 0]
     })";
-#else
-    std::string ycbcr_ci_pnext = R"("NULL")";
-#endif  // VK_USE_PLATFORM_SCREEN_QNX
 
-    const std::string json{R"({
-    "EnabledExtensions" : 
-    [
-        "VK_EXT_robustness2"
-    ],
-    "GraphicsPipelineState" : 
-    {
-        "DescriptorSetLayouts" : 
-        [
-            {
-                "DescriptorSetLayout1" : 
-                {
-                    "bindingCount" : 3,
-                    "flags" : "VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT",
-                    "pBindings" : 
-                    [
-                        {
-                            "binding" : 0,
-                            "descriptorCount" : 1,
-                            "descriptorType" : "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
-                            "pImmutableSamplers" : "NULL",
-                            "stageFlags" : "VK_SHADER_STAGE_COMPUTE_BIT"
-                        },
-                        {
-                            "binding" : 1,
-                            "descriptorCount" : 1,
-                            "descriptorType" : "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
-                            "pImmutableSamplers" : 
-                            [
-                                "ImmutableSampler1"
-                            ],
-                            "stageFlags" : "VK_SHADER_STAGE_FRAGMENT_BIT"
-                        },
-                        {
-                            "binding" : 2,
-                            "descriptorCount" : 1,
-                            "descriptorType" : "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
-                            "pImmutableSamplers" : 
-                            [
-                                "YcbcrSampler1"
-                            ],
-                            "stageFlags" : "VK_SHADER_STAGE_FRAGMENT_BIT"
-                        }
-                    ],
-                    "pNext" : 
-                    {
-                        "bindingCount" : 1,
-                        "pBindingFlags" : 
-                        [
-                            "VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT"
-                        ],
-                        "pNext" : "NULL",
-                        "sType" : "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO"
-                    },
-                    "sType" : "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO"
-                }
-            }
-        ],
-)"
-                           R"(
-        "GraphicsPipeline" : 
-        {
-            "sType" : "VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO",
-            "pNext": {
-                "sType": "VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT",
-                "pNext" : "NULL",
-                "flags": "0",
-                "discardRectangleMode": "VK_DISCARD_RECTANGLE_MODE_EXCLUSIVE_EXT",
-                "discardRectangleCount": 1,
-                "pDiscardRectangles": [
-                    {
-                        "offset":
-                        {
-                            "x" : 0,
-                            "y" : 0
-                        },
-                        "extent":
-                        {
-                            "width" : 51,
-                            "height" : 51
-                        }
-                    }
-                ]
-            },
-            "flags" : "0",
-            "stageCount" : 5,
-            "pStages": 
-            [
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                "pNext": {
-                    "pNext" : "NULL",
-                    "requiredSubgroupSize" : 64,
-                    "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO"
-                },
-                "flags" : "0",
-                "stage" : "VK_SHADER_STAGE_VERTEX_BIT",
-                "module" : 35,
-                "pName" : "main",
-                "pSpecializationInfo": 
-                "NULL"
-            },
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : "0",
-                "stage" : "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
-                "module" : 36,
-                "pName" : "main",
-                "pSpecializationInfo": 
-                "NULL"
-            },
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : "0",
-                "stage" : "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
-                "module" : 37,
-                "pName" : "main",
-                "pSpecializationInfo": 
-                "NULL"
-            },
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : "0",
-                "stage" : "VK_SHADER_STAGE_GEOMETRY_BIT",
-                "module" : 38,
-                "pName" : "main",
-                "pSpecializationInfo": 
-                "NULL"
-            },
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : "0",
-                "stage" : "VK_SHADER_STAGE_FRAGMENT_BIT",
-                "module" : 39,
-                "pName" : "main",
-                "pSpecializationInfo": 
-                "NULL"
-            }
-            ],
-            "pVertexInputState": 
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : 0,
-                "vertexBindingDescriptionCount" : 1,
-                "pVertexBindingDescriptions": 
-                [
-                {
-                    "binding" : 0,
-                    "stride" : 32,
-                    "inputRate" : "VK_VERTEX_INPUT_RATE_VERTEX"
-                }
-                ],
-                "vertexAttributeDescriptionCount" : 2,
-                "pVertexAttributeDescriptions": 
-                [
-                {
-                    "location" : 0,
-                    "binding" : 0,
-                    "format" : "VK_FORMAT_R32G32B32A32_SFLOAT",
-                    "offset" : 0
-                },
-                {
-                    "location" : 1,
-                    "binding" : 0,
-                    "format" : "VK_FORMAT_R32G32B32A32_SFLOAT",
-                    "offset" : 16
-                }
-                ]
-            },
-            "pInputAssemblyState": 
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : 0,
-                "topology" : "VK_PRIMITIVE_TOPOLOGY_PATCH_LIST",
-                "primitiveRestartEnable" : "VK_FALSE"
-            },
-            "pTessellationState": 
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : 0,
-                "patchControlPoints" : 4
-            },
-            "pViewportState": 
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : 0,
-                "viewportCount" : 1,
-                "pViewports": 
-                [
-                {
-                    "x" : 0,
-                    "y" : 0,
-                    "width" : 51,
-                    "height" : 51,
-                    "minDepth" : 0,
-                    "maxDepth" : 1
-                }
-                ],
-                "scissorCount" : 1,
-                "pScissors": 
-                [
-                {
-                    "offset": 
-                    {
-                        "x" : 0,
-                        "y" : 0
-                    },
-                    "extent": 
-                    {
-                        "width" : 51,
-                        "height" : 51
-                    }
-                }
-                ]
-            },
-            "pRasterizationState": 
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : 0,
-                "depthClampEnable" : "VK_FALSE",
-                "rasterizerDiscardEnable" : "VK_FALSE",
-                "polygonMode" : "VK_POLYGON_MODE_FILL",
-                "cullMode" : "0",
-                "frontFace" : "VK_FRONT_FACE_COUNTER_CLOCKWISE",
-                "depthBiasEnable" : "VK_FALSE",
-                "depthBiasConstantFactor" : 0,
-                "depthBiasClamp" : 0,
-                "depthBiasSlopeFactor" : 0,
-                "lineWidth" : 1
-            },
-            "pMultisampleState": 
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : 0,
-                "rasterizationSamples" : "VK_SAMPLE_COUNT_1_BIT",
-                "sampleShadingEnable" : "VK_FALSE",
-                "minSampleShading" : 1,
-                "pSampleMask":
-                "NULL",
-                "alphaToCoverageEnable" : "VK_FALSE",
-                "alphaToOneEnable" : "VK_FALSE"
-            },
-            "pDepthStencilState": 
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : 0,
-                "depthTestEnable" : "VK_TRUE",
-                "depthWriteEnable" : "VK_TRUE",
-                "depthCompareOp" : "VK_COMPARE_OP_LESS_OR_EQUAL",
-                "depthBoundsTestEnable" : "VK_FALSE",
-                "stencilTestEnable" : "VK_FALSE",
-                "front": 
-                {
-                    "failOp" : "VK_STENCIL_OP_KEEP",
-                    "passOp" : "VK_STENCIL_OP_KEEP",
-                    "depthFailOp" : "VK_STENCIL_OP_KEEP",
-                    "compareOp" : "VK_COMPARE_OP_NEVER",
-                    "compareMask" : 0,
-                    "writeMask" : 0,
-                    "reference" : 0
-                },
-                "back": 
-                {
-                    "failOp" : "VK_STENCIL_OP_KEEP",
-                    "passOp" : "VK_STENCIL_OP_KEEP",
-                    "depthFailOp" : "VK_STENCIL_OP_KEEP",
-                    "compareOp" : "VK_COMPARE_OP_NEVER",
-                    "compareMask" : 0,
-                    "writeMask" : 0,
-                    "reference" : 0
-                },
-                "minDepthBounds" : 0,
-                "maxDepthBounds" : 1
-            },
-            "pColorBlendState": 
-            {
-                "sType" : "VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO",
-                "pNext":"NULL",
-                "flags" : 0,
-                "logicOpEnable" : "VK_FALSE",
-                "logicOp" : "VK_LOGIC_OP_CLEAR",
-                "attachmentCount" : 1,
-                "pAttachments": 
-                [
-                {
-                    "blendEnable" : "VK_FALSE",
-                    "srcColorBlendFactor" : "VK_BLEND_FACTOR_ZERO",
-                    "dstColorBlendFactor" : "VK_BLEND_FACTOR_ZERO",
-                    "colorBlendOp" : "VK_BLEND_OP_ADD",
-                    "srcAlphaBlendFactor" : "VK_BLEND_FACTOR_ZERO",
-                    "dstAlphaBlendFactor" : "VK_BLEND_FACTOR_ZERO",
-                    "alphaBlendOp" : "VK_BLEND_OP_ADD",
-                    "colorWriteMask" : "VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT"
-                }
-                ],
-                "blendConstants":
-                [
-                0,
-                0,
-                0,
-                0
-                ]
-            },
-            "pDynamicState": {
-                "sType": "VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO",
-                "pNext": "NULL",
-                "flags": 0,
-                "dynamicStateCount": 3,
-                "pDynamicStates": [
-                    "VK_DYNAMIC_STATE_VIEWPORT",
-                    "VK_DYNAMIC_STATE_SCISSOR",
-                    "VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT"
-                ]
-            },
-            "layout" : 8,
-            "renderPass" : 6,
-            "subpass" : 0,
-            "basePipelineHandle" : "",
-            "basePipelineIndex" : 0
-        },
-)"
-                           R"(
-        "ImmutableSamplers" : 
-        [
-            {
-                "ImmutableSampler1" : 
-                {
-                    "addressModeU" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "addressModeV" : "VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT",
-                    "addressModeW" : "VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE",
-                    "anisotropyEnable" : "VK_FALSE",
-                    "borderColor" : "VK_BORDER_COLOR_FLOAT_CUSTOM_EXT",
-                    "compareEnable" : "VK_FALSE",
-                    "compareOp" : "VK_COMPARE_OP_NEVER",
-                    "flags" : 0,
-                    "magFilter" : "VK_FILTER_CUBIC_EXT",
-                    "maxAnisotropy" : 2.0,
-                    "maxLod" : 1000.0,
-                    "minFilter" : "VK_FILTER_NEAREST",
-                    "minLod" : 0.5,
-                    "mipLodBias" : 0.5,
-                    "mipmapMode" : "VK_SAMPLER_MIPMAP_MODE_LINEAR",
-                    "pNext" : 
-                    {
-                        "pNext" : "NULL",
-                        "reductionMode" : "VK_SAMPLER_REDUCTION_MODE_MAX",
-                        "sType" : "VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO"
-                    },
-                    "sType" : "VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO",
-                    "unnormalizedCoordinates" : "VK_TRUE"
-                }
-            },
-            {
-                "YcbcrSampler1" : 
-                {
-                    "addressModeU" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "addressModeV" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "addressModeW" : "VK_SAMPLER_ADDRESS_MODE_REPEAT",
-                    "anisotropyEnable" : "VK_FALSE",
-                    "borderColor" : "VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK",
-                    "compareEnable" : "VK_FALSE",
-                    "compareOp" : "VK_COMPARE_OP_NEVER",
-                    "flags" : 0,
-                    "magFilter" : "VK_FILTER_NEAREST",
-                    "maxAnisotropy" : 0.0,
-                    "maxLod" : 0.0,
-                    "minFilter" : "VK_FILTER_NEAREST",
-                    "minLod" : 0.0,
-                    "mipLodBias" : 0.0,
-                    "mipmapMode" : "VK_SAMPLER_MIPMAP_MODE_NEAREST",
-                    "pNext" : 
-                    {
-                        "conversion" : "YcbcrConversion1",
-                        "pNext" : "NULL",
-                        "sType" : "VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO"
-                    },
-                    "sType" : "VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO",
-                    "unnormalizedCoordinates" : "VK_FALSE"
-                }
-            }
-        ],
-)"
-                           R"(
-        "PhysicalDeviceFeatures" : 
-        {
-            "features" : 
-            {
-                "alphaToOne" : "VK_FALSE",
-                "depthBiasClamp" : "VK_FALSE",
-                "depthBounds" : "VK_FALSE",
-                "depthClamp" : "VK_FALSE",
-                "drawIndirectFirstInstance" : "VK_FALSE",
-                "dualSrcBlend" : "VK_FALSE",
-                "fillModeNonSolid" : "VK_FALSE",
-                "fragmentStoresAndAtomics" : "VK_FALSE",
-                "fullDrawIndexUint32" : "VK_FALSE",
-                "geometryShader" : "VK_FALSE",
-                "imageCubeArray" : "VK_FALSE",
-                "independentBlend" : "VK_FALSE",
-                "inheritedQueries" : "VK_FALSE",
-                "largePoints" : "VK_FALSE",
-                "logicOp" : "VK_FALSE",
-                "multiDrawIndirect" : "VK_FALSE",
-                "multiViewport" : "VK_FALSE",
-                "occlusionQueryPrecise" : "VK_FALSE",
-                "pipelineStatisticsQuery" : "VK_FALSE",
-                "robustBufferAccess" : "VK_TRUE",
-                "sampleRateShading" : "VK_FALSE",
-                "samplerAnisotropy" : "VK_FALSE",
-                "shaderClipDistance" : "VK_FALSE",
-                "shaderCullDistance" : "VK_FALSE",
-                "shaderFloat64" : "VK_FALSE",
-                "shaderImageGatherExtended" : "VK_FALSE",
-                "shaderInt16" : "VK_FALSE",
-                "shaderInt64" : "VK_FALSE",
-                "shaderResourceMinLod" : "VK_FALSE",
-                "shaderResourceResidency" : "VK_FALSE",
-                "shaderSampledImageArrayDynamicIndexing" : "VK_FALSE",
-                "shaderStorageBufferArrayDynamicIndexing" : "VK_FALSE",
-                "shaderStorageImageArrayDynamicIndexing" : "VK_FALSE",
-                "shaderStorageImageExtendedFormats" : "VK_FALSE",
-                "shaderStorageImageMultisample" : "VK_FALSE",
-                "shaderStorageImageReadWithoutFormat" : "VK_FALSE",
-                "shaderStorageImageWriteWithoutFormat" : "VK_FALSE",
-                "shaderTessellationAndGeometryPointSize" : "VK_FALSE",
-                "shaderUniformBufferArrayDynamicIndexing" : "VK_FALSE",
-                "sparseBinding" : "VK_FALSE",
-                "sparseResidency16Samples" : "VK_FALSE",
-                "sparseResidency2Samples" : "VK_FALSE",
-                "sparseResidency4Samples" : "VK_FALSE",
-                "sparseResidency8Samples" : "VK_FALSE",
-                "sparseResidencyAliased" : "VK_FALSE",
-                "sparseResidencyBuffer" : "VK_FALSE",
-                "sparseResidencyImage2D" : "VK_FALSE",
-                "sparseResidencyImage3D" : "VK_FALSE",
-                "tessellationShader" : "VK_FALSE",
-                "textureCompressionASTC_LDR" : "VK_FALSE",
-                "textureCompressionBC" : "VK_FALSE",
-                "textureCompressionETC2" : "VK_FALSE",
-                "variableMultisampleRate" : "VK_FALSE",
-                "vertexPipelineStoresAndAtomics" : "VK_FALSE",
-                "wideLines" : "VK_FALSE"
-            },
-            "pNext" : 
-            {
-                "pNext" : "NULL",
-                "sType" : "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES",
-                "synchronization2" : "VK_TRUE"
-            },
-            "sType" : "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2"
-        },
-)"
-                           R"(
-        "PipelineLayout" : 
-        {
-            "flags" : 0,
-            "pNext" : "NULL",
-            "pPushConstantRanges" : 
-            [
-                {
-                    "offset" : 0,
-                    "size" : 4,
-                    "stageFlags" : "VK_SHADER_STAGE_COMPUTE_BIT"
-                }
-            ],
-            "pSetLayouts" : 
-            [
-                "DescriptorSetLayout1"
-            ],
-            "pushConstantRangeCount" : 1,
-            "sType" : "VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO",
-            "setLayoutCount" : 1
-        },
-)"
-                           R"(
-        "Renderpass" : 
-        {
-            "attachmentCount" : 2,
-            "dependencyCount" : 2,
-            "flags" : 0,
-            "pAttachments" : 
-            [
-                {
-                    "finalLayout" : "VK_IMAGE_LAYOUT_PRESENT_SRC_KHR",
-                    "flags" : 0,
-                    "format" : "VK_FORMAT_R8G8B8A8_UNORM",
-                    "initialLayout" : "VK_IMAGE_LAYOUT_UNDEFINED",
-                    "loadOp" : "VK_ATTACHMENT_LOAD_OP_CLEAR",
-                    "samples" : "VK_SAMPLE_COUNT_1_BIT",
-                    "stencilLoadOp" : "VK_ATTACHMENT_LOAD_OP_DONT_CARE",
-                    "stencilStoreOp" : "VK_ATTACHMENT_STORE_OP_DONT_CARE",
-                    "storeOp" : "VK_ATTACHMENT_STORE_OP_STORE"
-                },
-                {
-                    "finalLayout" : "VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL",
-                    "flags" : 0,
-                    "format" : "VK_FORMAT_D16_UNORM",
-                    "initialLayout" : "VK_IMAGE_LAYOUT_UNDEFINED",
-                    "loadOp" : "VK_ATTACHMENT_LOAD_OP_CLEAR",
-                    "samples" : "VK_SAMPLE_COUNT_1_BIT",
-                    "stencilLoadOp" : "VK_ATTACHMENT_LOAD_OP_DONT_CARE",
-                    "stencilStoreOp" : "VK_ATTACHMENT_STORE_OP_DONT_CARE",
-                    "storeOp" : "VK_ATTACHMENT_STORE_OP_DONT_CARE"
-                }
-            ],
-            "pDependencies" : 
-            [
-                {
-                    "dependencyFlags" : 0,
-                    "dstAccessMask" : "VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT",
-                    "dstStageMask" : "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
-                    "dstSubpass" : 0,
-                    "srcAccessMask" : "VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT",
-                    "srcStageMask" : "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
-                    "srcSubpass" : 4294967295
-                },
-                {
-                    "dependencyFlags" : 0,
-                    "dstAccessMask" : "VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT",
-                    "dstStageMask" : "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
-                    "dstSubpass" : 0,
-                    "srcAccessMask" : 0,
-                    "srcStageMask" : "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
-                    "srcSubpass" : 4294967295
-                }
-            ],
-            "pNext" : "NULL",
-            "pSubpasses" : 
-            [
-                {
-                    "colorAttachmentCount" : 1,
-                    "flags" : 0,
-                    "inputAttachmentCount" : 0,
-                    "pColorAttachments" : 
-                    [
-                        {
-                            "attachment" : 0,
-                            "layout" : "VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL"
-                        }
-                    ],
-                    "pDepthStencilAttachment" : 
-                    {
-                        "attachment" : 1,
-                        "layout" : "VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL"
-                    },
-                    "pInputAttachments" : "NULL",
-                    "pPreserveAttachments" : "NULL",
-                    "pResolveAttachments" : "NULL",
-                    "pipelineBindPoint" : "VK_PIPELINE_BIND_POINT_GRAPHICS",
-                    "preserveAttachmentCount" : 0
-                }
-            ],
-            "sType" : "VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO",
-            "subpassCount" : 1
-        },
-)"
-                           R"(
-        "ShaderFileNames" : 
-        [
-            {
-                "filename" : "shader.vert.spv",
-                "stage" : "VK_SHADER_STAGE_VERTEX_BIT"
-            },
-            {
-                "filename" : "shader.frag.spv",
-                "stage" : "VK_SHADER_STAGE_FRAGMENT_BIT"
-            }
-        ],
-        "YcbcrSamplers" : 
-        [
-            {
-                "YcbcrConversion1" : 
-                {
-                    "sType" : "VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO",
-                    "pNext": )" +
-                           ycbcr_ci_pnext + R"(,
-                    "format": "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16",
-                    "ycbcrModel": "VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020",
-                    "ycbcrRange": "VK_SAMPLER_YCBCR_RANGE_ITU_NARROW",
-                    "components": {
-                        "r": "VK_COMPONENT_SWIZZLE_A",
-                        "g": "VK_COMPONENT_SWIZZLE_B",
-                        "b": "VK_COMPONENT_SWIZZLE_G",
-                        "a": "VK_COMPONENT_SWIZZLE_R"
-                    },
-                    "xChromaOffset": "VK_CHROMA_LOCATION_COSITED_EVEN",
-                    "yChromaOffset": "VK_CHROMA_LOCATION_MIDPOINT",
-                    "chromaFilter": "VK_FILTER_CUBIC_EXT",
-                    "forceExplicitReconstruction": "VK_TRUE"
-                }
-            }
-        ]
-    },
-    "PipelineUUID" : 
-    [
-        85,
-        43,
-        255,
-        24,
-        155,
-        64,
-        62,
-        24,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0
-    ]
-})"};
-    EXPECT_TRUE(ValidatePipelineJson(json));
+    VpjData ref_data{};
+    ref_data.enabledExtensionCount = 1;
+    ref_data.ppEnabledExtensions = enabled_extensions;
+    ref_data.graphicsPipelineState.pGraphicsPipeline = &gp_ci;
+    ref_data.graphicsPipelineState.pRenderPass = &renderPass;
+    ref_data.graphicsPipelineState.pPipelineLayout = &pl_ci;
+    ref_data.graphicsPipelineState.immutableSamplerCount = 2;
+    ref_data.graphicsPipelineState.ppImmutableSamplerNames = sampler_names;
+    ref_data.graphicsPipelineState.pImmutableSamplers = sampler_ci;
+    ref_data.graphicsPipelineState.ycbcrSamplerCount = 1;
+    ref_data.graphicsPipelineState.ppYcbcrSamplerNames = ycbcr_names;
+    ref_data.graphicsPipelineState.pYcbcrSamplers = &ycbcr_ci;
+    ref_data.graphicsPipelineState.descriptorSetLayoutCount = 1;
+    ref_data.graphicsPipelineState.pDescriptorSetLayouts = &dsl_ci;
+    ref_data.graphicsPipelineState.ppDescriptorSetLayoutNames = dsl_names;
+    ref_data.graphicsPipelineState.pPhysicalDeviceFeatures = &pdf;
+    ref_data.graphicsPipelineState.shaderFileNameCount = (uint32_t)shaderFileNames.size();
+    ref_data.graphicsPipelineState.pShaderFileNames = shaderFileNames.data();
 
-    VpjData data;
+    ref_data.pipelineUUID[0] = 85;
+    ref_data.pipelineUUID[1] = 43;
+    ref_data.pipelineUUID[2] = 255;
+    ref_data.pipelineUUID[3] = 24;
+    ref_data.pipelineUUID[4] = 155;
+    ref_data.pipelineUUID[5] = 64;
+    ref_data.pipelineUUID[6] = 62;
+    ref_data.pipelineUUID[7] = 24;
+
     EXPECT_TRUE(vpjParsePipelineJson(this->parser_, json.c_str(), &data, &msg_));
     CHECK_PARSE(true);
-    const auto& rp_ci = *reinterpret_cast<const VkRenderPassCreateInfo*>(data.graphicsPipelineState.pRenderPass);
-    const auto& dsl_ci =
-        reinterpret_cast<const VkDescriptorSetLayoutCreateInfo*>(data.graphicsPipelineState.pDescriptorSetLayouts)[0];
-    const auto& dsl_names = data.graphicsPipelineState.ppDescriptorSetLayoutNames;
-    const auto& bf_ci = *reinterpret_cast<const VkDescriptorSetLayoutBindingFlagsCreateInfo*>(dsl_ci.pNext);
-    const auto& pl_ci = *reinterpret_cast<const VkPipelineLayoutCreateInfo*>(data.graphicsPipelineState.pPipelineLayout);
-    const auto& gp_ci = *reinterpret_cast<const VkGraphicsPipelineCreateInfo*>(data.graphicsPipelineState.pGraphicsPipeline);
-    const auto& pdrs_ci = *reinterpret_cast<const VkPipelineDiscardRectangleStateCreateInfoEXT*>(gp_ci.pNext);
-    const auto& pvis_ci = *reinterpret_cast<const VkPipelineVertexInputStateCreateInfo*>(gp_ci.pVertexInputState);
-    const auto& pias_ci = *reinterpret_cast<const VkPipelineInputAssemblyStateCreateInfo*>(gp_ci.pInputAssemblyState);
-    const auto& pts_ci = *reinterpret_cast<const VkPipelineTessellationStateCreateInfo*>(gp_ci.pTessellationState);
-    const auto& pvs_ci = *reinterpret_cast<const VkPipelineViewportStateCreateInfo*>(gp_ci.pViewportState);
-    const auto& prs_ci = *reinterpret_cast<const VkPipelineRasterizationStateCreateInfo*>(gp_ci.pRasterizationState);
-    const auto& pmss_ci = *reinterpret_cast<const VkPipelineMultisampleStateCreateInfo*>(gp_ci.pMultisampleState);
-    const auto& pdss_ci = *reinterpret_cast<const VkPipelineDepthStencilStateCreateInfo*>(gp_ci.pDepthStencilState);
-    const auto& pcbs_ci = *reinterpret_cast<const VkPipelineColorBlendStateCreateInfo*>(gp_ci.pColorBlendState);
-    const auto& pds_ci = *reinterpret_cast<const VkPipelineDynamicStateCreateInfo*>(gp_ci.pDynamicState);
-    const auto& pssrss_ci = *reinterpret_cast<const VkPipelineShaderStageRequiredSubgroupSizeCreateInfo*>(gp_ci.pStages[0].pNext);
 
-    const auto& sampler_cis = reinterpret_cast<const VkSamplerCreateInfo*>(data.graphicsPipelineState.pImmutableSamplers);
-    const auto& sampler_names = data.graphicsPipelineState.ppImmutableSamplerNames;
-    const auto& srm_ci = *reinterpret_cast<const VkSamplerReductionModeCreateInfo*>(sampler_cis[0].pNext);
-    const auto& ycbcrci = *reinterpret_cast<const VkSamplerYcbcrConversionInfo*>(sampler_cis[1].pNext);
-    const auto& ycbcr_names = data.graphicsPipelineState.ppYcbcrSamplerNames;
-    const auto& ycbcr_ci =
-        reinterpret_cast<const VkSamplerYcbcrConversionCreateInfo*>(data.graphicsPipelineState.pYcbcrSamplers)[0];
-
-    const auto& sfn = data.graphicsPipelineState.pShaderFileNames;
-
-    EXPECT_EQ(gp_ci.sType, VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO);
-    EXPECT_EQ(pdrs_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT);
-    EXPECT_EQ(pdrs_ci.pNext, nullptr);
-    EXPECT_EQ(pdrs_ci.flags, 0);
-    EXPECT_EQ(pdrs_ci.discardRectangleMode, VK_DISCARD_RECTANGLE_MODE_EXCLUSIVE_EXT);
-    EXPECT_EQ(pdrs_ci.discardRectangleCount, 1);
-    EXPECT_EQ(pdrs_ci.pDiscardRectangles[0].offset.x, 0);
-    EXPECT_EQ(pdrs_ci.pDiscardRectangles[0].offset.y, 0);
-    EXPECT_EQ(pdrs_ci.pDiscardRectangles[0].extent.width, 51);
-    EXPECT_EQ(pdrs_ci.pDiscardRectangles[0].extent.height, 51);
-    EXPECT_EQ(gp_ci.flags, 0);
-    EXPECT_EQ(gp_ci.stageCount, 5);
-    EXPECT_EQ(gp_ci.pStages[0].sType, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO);
-    EXPECT_EQ(pssrss_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO);
-    EXPECT_EQ(pssrss_ci.pNext, nullptr);
-    EXPECT_EQ(pssrss_ci.requiredSubgroupSize, 64);
-    EXPECT_EQ(gp_ci.pStages[0].flags, 0);
-    EXPECT_EQ(gp_ci.pStages[0].stage, VK_SHADER_STAGE_VERTEX_BIT);
-    EXPECT_EQ(gp_ci.pStages[0].module, reinterpret_cast<void*>(35));
-    EXPECT_STREQ(gp_ci.pStages[0].pName, "main");
-    EXPECT_EQ(gp_ci.pStages[0].pSpecializationInfo, nullptr);
-    EXPECT_EQ(gp_ci.pStages[1].sType, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO);
-    EXPECT_EQ(gp_ci.pStages[1].pNext, nullptr);
-    EXPECT_EQ(gp_ci.pStages[1].flags, 0);
-    EXPECT_EQ(gp_ci.pStages[1].stage, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT);
-    EXPECT_EQ(gp_ci.pStages[1].module, reinterpret_cast<void*>(36));
-    EXPECT_STREQ(gp_ci.pStages[1].pName, "main");
-    EXPECT_EQ(gp_ci.pStages[1].pSpecializationInfo, nullptr);
-    EXPECT_EQ(gp_ci.pStages[2].sType, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO);
-    EXPECT_EQ(gp_ci.pStages[2].pNext, nullptr);
-    EXPECT_EQ(gp_ci.pStages[2].flags, 0);
-    EXPECT_EQ(gp_ci.pStages[2].stage, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT);
-    EXPECT_EQ(gp_ci.pStages[2].module, reinterpret_cast<void*>(37));
-    EXPECT_STREQ(gp_ci.pStages[2].pName, "main");
-    EXPECT_EQ(gp_ci.pStages[2].pSpecializationInfo, nullptr);
-    EXPECT_EQ(gp_ci.pStages[3].sType, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO);
-    EXPECT_EQ(gp_ci.pStages[3].pNext, nullptr);
-    EXPECT_EQ(gp_ci.pStages[3].flags, 0);
-    EXPECT_EQ(gp_ci.pStages[3].stage, VK_SHADER_STAGE_GEOMETRY_BIT);
-    EXPECT_EQ(gp_ci.pStages[3].module, reinterpret_cast<void*>(38));
-    EXPECT_STREQ(gp_ci.pStages[3].pName, "main");
-    EXPECT_EQ(gp_ci.pStages[3].pSpecializationInfo, nullptr);
-    EXPECT_EQ(gp_ci.pStages[4].sType, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO);
-    EXPECT_EQ(gp_ci.pStages[4].pNext, nullptr);
-    EXPECT_EQ(gp_ci.pStages[4].flags, 0);
-    EXPECT_EQ(gp_ci.pStages[4].stage, VK_SHADER_STAGE_FRAGMENT_BIT);
-    EXPECT_EQ(gp_ci.pStages[4].module, reinterpret_cast<void*>(39));
-    EXPECT_STREQ(gp_ci.pStages[4].pName, "main");
-    EXPECT_EQ(gp_ci.pStages[4].pSpecializationInfo, nullptr);
-    EXPECT_EQ(pvis_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO);
-    EXPECT_EQ(pvis_ci.pNext, nullptr);
-    EXPECT_EQ(pvis_ci.flags, 0);
-    EXPECT_EQ(pvis_ci.vertexBindingDescriptionCount, 1);
-    EXPECT_EQ(pvis_ci.pVertexBindingDescriptions[0].binding, 0);
-    EXPECT_EQ(pvis_ci.pVertexBindingDescriptions[0].stride, 32);
-    EXPECT_EQ(pvis_ci.pVertexBindingDescriptions[0].inputRate, VK_VERTEX_INPUT_RATE_VERTEX);
-    EXPECT_EQ(pvis_ci.vertexAttributeDescriptionCount, 2);
-    EXPECT_EQ(pvis_ci.pVertexAttributeDescriptions[0].location, 0);
-    EXPECT_EQ(pvis_ci.pVertexAttributeDescriptions[0].binding, 0);
-    EXPECT_EQ(pvis_ci.pVertexAttributeDescriptions[0].format, VK_FORMAT_R32G32B32A32_SFLOAT);
-    EXPECT_EQ(pvis_ci.pVertexAttributeDescriptions[0].offset, 0);
-    EXPECT_EQ(pvis_ci.pVertexAttributeDescriptions[1].location, 1);
-    EXPECT_EQ(pvis_ci.pVertexAttributeDescriptions[1].binding, 0);
-    EXPECT_EQ(pvis_ci.pVertexAttributeDescriptions[1].format, VK_FORMAT_R32G32B32A32_SFLOAT);
-    EXPECT_EQ(pvis_ci.pVertexAttributeDescriptions[1].offset, 16);
-    EXPECT_EQ(pias_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO);
-    EXPECT_EQ(pias_ci.pNext, nullptr);
-    EXPECT_EQ(pias_ci.flags, 0);
-    EXPECT_EQ(pias_ci.topology, VK_PRIMITIVE_TOPOLOGY_PATCH_LIST);
-    EXPECT_EQ(pias_ci.primitiveRestartEnable, VK_FALSE);
-    EXPECT_EQ(pts_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO);
-    EXPECT_EQ(pts_ci.pNext, nullptr);
-    EXPECT_EQ(pts_ci.flags, 0);
-    EXPECT_EQ(pts_ci.patchControlPoints, 4);
-    EXPECT_EQ(pvs_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO);
-    EXPECT_EQ(pvs_ci.pNext, nullptr);
-    EXPECT_EQ(pvs_ci.flags, 0);
-    EXPECT_EQ(pvs_ci.viewportCount, 1);
-    EXPECT_EQ(pvs_ci.pViewports[0].x, 0);
-    EXPECT_EQ(pvs_ci.pViewports[0].y, 0);
-    EXPECT_EQ(pvs_ci.pViewports[0].width, 51);
-    EXPECT_EQ(pvs_ci.pViewports[0].height, 51);
-    EXPECT_EQ(pvs_ci.pViewports[0].minDepth, 0);
-    EXPECT_EQ(pvs_ci.pViewports[0].maxDepth, 1);
-    EXPECT_EQ(pvs_ci.scissorCount, 1);
-    EXPECT_EQ(pvs_ci.pScissors[0].offset.x, 0);
-    EXPECT_EQ(pvs_ci.pScissors[0].offset.y, 0);
-    EXPECT_EQ(pvs_ci.pScissors[0].extent.width, 51);
-    EXPECT_EQ(pvs_ci.pScissors[0].extent.height, 51);
-    EXPECT_EQ(prs_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO);
-    EXPECT_EQ(prs_ci.pNext, nullptr);
-    EXPECT_EQ(prs_ci.flags, 0);
-    EXPECT_EQ(prs_ci.depthClampEnable, VK_FALSE);
-    EXPECT_EQ(prs_ci.rasterizerDiscardEnable, VK_FALSE);
-    EXPECT_EQ(prs_ci.polygonMode, VK_POLYGON_MODE_FILL);
-    EXPECT_EQ(prs_ci.cullMode, 0);
-    EXPECT_EQ(prs_ci.frontFace, VK_FRONT_FACE_COUNTER_CLOCKWISE);
-    EXPECT_EQ(prs_ci.depthBiasEnable, VK_FALSE);
-    EXPECT_EQ(prs_ci.depthBiasConstantFactor, 0);
-    EXPECT_EQ(prs_ci.depthBiasClamp, 0);
-    EXPECT_EQ(prs_ci.depthBiasSlopeFactor, 0);
-    EXPECT_EQ(prs_ci.lineWidth, 1);
-    EXPECT_EQ(pmss_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO);
-    EXPECT_EQ(pmss_ci.pNext, nullptr);
-    EXPECT_EQ(pmss_ci.flags, 0);
-    EXPECT_EQ(pmss_ci.rasterizationSamples, VK_SAMPLE_COUNT_1_BIT);
-    EXPECT_EQ(pmss_ci.sampleShadingEnable, VK_FALSE);
-    EXPECT_EQ(pmss_ci.minSampleShading, 1);
-    EXPECT_EQ(pmss_ci.pSampleMask, nullptr);
-    EXPECT_EQ(pmss_ci.alphaToCoverageEnable, VK_FALSE);
-    EXPECT_EQ(pmss_ci.alphaToOneEnable, VK_FALSE);
-    EXPECT_EQ(pdss_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO);
-    EXPECT_EQ(pdss_ci.pNext, nullptr);
-    EXPECT_EQ(pdss_ci.flags, 0);
-    EXPECT_EQ(pdss_ci.depthTestEnable, VK_TRUE);
-    EXPECT_EQ(pdss_ci.depthWriteEnable, VK_TRUE);
-    EXPECT_EQ(pdss_ci.depthCompareOp, VK_COMPARE_OP_LESS_OR_EQUAL);
-    EXPECT_EQ(pdss_ci.depthBoundsTestEnable, VK_FALSE);
-    EXPECT_EQ(pdss_ci.stencilTestEnable, VK_FALSE);
-    EXPECT_EQ(pdss_ci.front.failOp, VK_STENCIL_OP_KEEP);
-    EXPECT_EQ(pdss_ci.front.passOp, VK_STENCIL_OP_KEEP);
-    EXPECT_EQ(pdss_ci.front.depthFailOp, VK_STENCIL_OP_KEEP);
-    EXPECT_EQ(pdss_ci.front.compareOp, VK_COMPARE_OP_NEVER);
-    EXPECT_EQ(pdss_ci.front.compareMask, 0);
-    EXPECT_EQ(pdss_ci.front.writeMask, 0);
-    EXPECT_EQ(pdss_ci.front.reference, 0);
-    EXPECT_EQ(pdss_ci.back.failOp, VK_STENCIL_OP_KEEP);
-    EXPECT_EQ(pdss_ci.back.passOp, VK_STENCIL_OP_KEEP);
-    EXPECT_EQ(pdss_ci.back.depthFailOp, VK_STENCIL_OP_KEEP);
-    EXPECT_EQ(pdss_ci.back.compareOp, VK_COMPARE_OP_NEVER);
-    EXPECT_EQ(pdss_ci.back.compareMask, 0);
-    EXPECT_EQ(pdss_ci.back.writeMask, 0);
-    EXPECT_EQ(pdss_ci.back.reference, 0);
-    EXPECT_EQ(pdss_ci.minDepthBounds, 0);
-    EXPECT_EQ(pdss_ci.maxDepthBounds, 1);
-    EXPECT_EQ(pcbs_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO);
-    EXPECT_EQ(pcbs_ci.pNext, nullptr);
-    EXPECT_EQ(pcbs_ci.flags, 0);
-    EXPECT_EQ(pcbs_ci.logicOpEnable, VK_FALSE);
-    EXPECT_EQ(pcbs_ci.logicOp, VK_LOGIC_OP_CLEAR);
-    EXPECT_EQ(pcbs_ci.attachmentCount, 1);
-    EXPECT_EQ(pcbs_ci.pAttachments[0].blendEnable, VK_FALSE);
-    EXPECT_EQ(pcbs_ci.pAttachments[0].srcColorBlendFactor, VK_BLEND_FACTOR_ZERO);
-    EXPECT_EQ(pcbs_ci.pAttachments[0].dstColorBlendFactor, VK_BLEND_FACTOR_ZERO);
-    EXPECT_EQ(pcbs_ci.pAttachments[0].colorBlendOp, VK_BLEND_OP_ADD);
-    EXPECT_EQ(pcbs_ci.pAttachments[0].srcAlphaBlendFactor, VK_BLEND_FACTOR_ZERO);
-    EXPECT_EQ(pcbs_ci.pAttachments[0].dstAlphaBlendFactor, VK_BLEND_FACTOR_ZERO);
-    EXPECT_EQ(pcbs_ci.pAttachments[0].alphaBlendOp, VK_BLEND_OP_ADD);
-    EXPECT_EQ(pcbs_ci.pAttachments[0].colorWriteMask,
-              VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT);
-    EXPECT_EQ(pcbs_ci.blendConstants[0], 0);
-    EXPECT_EQ(pcbs_ci.blendConstants[1], 0);
-    EXPECT_EQ(pcbs_ci.blendConstants[2], 0);
-    EXPECT_EQ(pcbs_ci.blendConstants[3], 0);
-    EXPECT_EQ(pds_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO);
-    EXPECT_EQ(pds_ci.pNext, nullptr);
-    EXPECT_EQ(pds_ci.flags, 0);
-    EXPECT_EQ(pds_ci.dynamicStateCount, 3);
-    EXPECT_EQ(pds_ci.pDynamicStates[0], VK_DYNAMIC_STATE_VIEWPORT);
-    EXPECT_EQ(pds_ci.pDynamicStates[1], VK_DYNAMIC_STATE_SCISSOR);
-    EXPECT_EQ(pds_ci.pDynamicStates[2], VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT);
-    EXPECT_EQ(gp_ci.layout, reinterpret_cast<void*>(8));
-    EXPECT_EQ(gp_ci.renderPass, reinterpret_cast<void*>(6));
-    EXPECT_EQ(gp_ci.subpass, 0);
-    EXPECT_EQ(gp_ci.basePipelineHandle, VK_NULL_HANDLE);
-    EXPECT_EQ(gp_ci.basePipelineIndex, 0);
-
-    EXPECT_EQ(rp_ci.sType, VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO);
-    EXPECT_EQ(rp_ci.pNext, nullptr);
-    EXPECT_EQ(rp_ci.flags, 0);
-    EXPECT_EQ(rp_ci.attachmentCount, 2);
-    EXPECT_EQ(rp_ci.pAttachments[0].flags, 0);
-    EXPECT_EQ(rp_ci.pAttachments[0].format, VK_FORMAT_R8G8B8A8_UNORM);
-    EXPECT_EQ(rp_ci.pAttachments[0].samples, VK_SAMPLE_COUNT_1_BIT);
-    EXPECT_EQ(rp_ci.pAttachments[0].loadOp, VK_ATTACHMENT_LOAD_OP_CLEAR);
-    EXPECT_EQ(rp_ci.pAttachments[0].storeOp, VK_ATTACHMENT_STORE_OP_STORE);
-    EXPECT_EQ(rp_ci.pAttachments[0].stencilLoadOp, VK_ATTACHMENT_LOAD_OP_DONT_CARE);
-    EXPECT_EQ(rp_ci.pAttachments[0].stencilStoreOp, VK_ATTACHMENT_STORE_OP_DONT_CARE);
-    EXPECT_EQ(rp_ci.pAttachments[0].initialLayout, VK_IMAGE_LAYOUT_UNDEFINED);
-    EXPECT_EQ(rp_ci.pAttachments[0].finalLayout, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
-    EXPECT_EQ(rp_ci.pAttachments[1].flags, 0);
-    EXPECT_EQ(rp_ci.pAttachments[1].format, VK_FORMAT_D16_UNORM);
-    EXPECT_EQ(rp_ci.pAttachments[1].samples, VK_SAMPLE_COUNT_1_BIT);
-    EXPECT_EQ(rp_ci.pAttachments[1].loadOp, VK_ATTACHMENT_LOAD_OP_CLEAR);
-    EXPECT_EQ(rp_ci.pAttachments[1].storeOp, VK_ATTACHMENT_STORE_OP_DONT_CARE);
-    EXPECT_EQ(rp_ci.pAttachments[1].stencilLoadOp, VK_ATTACHMENT_LOAD_OP_DONT_CARE);
-    EXPECT_EQ(rp_ci.pAttachments[1].stencilStoreOp, VK_ATTACHMENT_STORE_OP_DONT_CARE);
-    EXPECT_EQ(rp_ci.pAttachments[1].initialLayout, VK_IMAGE_LAYOUT_UNDEFINED);
-    EXPECT_EQ(rp_ci.pAttachments[1].finalLayout, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
-    EXPECT_EQ(rp_ci.subpassCount, 1);
-    EXPECT_EQ(rp_ci.pSubpasses[0].flags, 0);
-    EXPECT_EQ(rp_ci.pSubpasses[0].pipelineBindPoint, VK_PIPELINE_BIND_POINT_GRAPHICS);
-    EXPECT_EQ(rp_ci.pSubpasses[0].inputAttachmentCount, 0);
-    EXPECT_EQ(rp_ci.pSubpasses[0].pInputAttachments, nullptr);
-    EXPECT_EQ(rp_ci.pSubpasses[0].colorAttachmentCount, 1);
-    EXPECT_EQ(rp_ci.pSubpasses[0].pColorAttachments[0].attachment, 0);
-    EXPECT_EQ(rp_ci.pSubpasses[0].pColorAttachments[0].layout, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
-    EXPECT_EQ(rp_ci.pSubpasses[0].pResolveAttachments, nullptr);
-    EXPECT_EQ(rp_ci.pSubpasses[0].pDepthStencilAttachment[0].attachment, 1);
-    EXPECT_EQ(rp_ci.pSubpasses[0].pDepthStencilAttachment[0].layout, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
-    EXPECT_EQ(rp_ci.pSubpasses[0].preserveAttachmentCount, 0);
-    EXPECT_EQ(rp_ci.pSubpasses[0].pPreserveAttachments, nullptr);
-    EXPECT_EQ(rp_ci.dependencyCount, 2);
-    EXPECT_EQ(rp_ci.pDependencies[0].srcSubpass, VK_SUBPASS_EXTERNAL);
-    EXPECT_EQ(rp_ci.pDependencies[0].dstSubpass, 0);
-    EXPECT_EQ(rp_ci.pDependencies[0].srcStageMask,
-              VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT);
-    EXPECT_EQ(rp_ci.pDependencies[0].dstStageMask,
-              VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT);
-    EXPECT_EQ(rp_ci.pDependencies[0].srcAccessMask, VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
-    EXPECT_EQ(rp_ci.pDependencies[0].dstAccessMask,
-              VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
-    EXPECT_EQ(rp_ci.pDependencies[0].dependencyFlags, 0);
-    EXPECT_EQ(rp_ci.pDependencies[1].srcSubpass, VK_SUBPASS_EXTERNAL);
-    EXPECT_EQ(rp_ci.pDependencies[1].dstSubpass, 0);
-    EXPECT_EQ(rp_ci.pDependencies[1].srcStageMask, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
-    EXPECT_EQ(rp_ci.pDependencies[1].dstStageMask, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
-    EXPECT_EQ(rp_ci.pDependencies[1].srcAccessMask, 0);
-    EXPECT_EQ(rp_ci.pDependencies[1].dstAccessMask, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT);
-    EXPECT_EQ(rp_ci.pDependencies[1].dependencyFlags, 0);
-
-    EXPECT_EQ(pl_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO);
-    EXPECT_EQ(pl_ci.pNext, nullptr);
-    EXPECT_EQ(pl_ci.flags, 0);
-    EXPECT_EQ(pl_ci.setLayoutCount, 1);
-    EXPECT_EQ(pl_ci.pSetLayouts[0], reinterpret_cast<void*>(0));
-    EXPECT_EQ(pl_ci.pushConstantRangeCount, 1);
-    EXPECT_EQ(pl_ci.pPushConstantRanges[0].stageFlags, VK_SHADER_STAGE_COMPUTE_BIT);
-    EXPECT_EQ(pl_ci.pPushConstantRanges[0].offset, 0);
-    EXPECT_EQ(pl_ci.pPushConstantRanges[0].size, 4);
-
-    EXPECT_EQ(data.graphicsPipelineState.descriptorSetLayoutCount, 1);
-    EXPECT_STREQ(dsl_names[0], "DescriptorSetLayout1");
-    EXPECT_EQ(dsl_ci.sType, VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO);
-    EXPECT_EQ(bf_ci.sType, VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO);
-    EXPECT_EQ(bf_ci.pNext, nullptr);
-    EXPECT_EQ(bf_ci.bindingCount, 1);
-    EXPECT_EQ(bf_ci.pBindingFlags[0], VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT);
-    EXPECT_EQ(dsl_ci.flags, VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT);
-    EXPECT_EQ(dsl_ci.bindingCount, 3);
-    EXPECT_EQ(dsl_ci.pBindings[0].binding, 0);
-    EXPECT_EQ(dsl_ci.pBindings[0].descriptorType, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-    EXPECT_EQ(dsl_ci.pBindings[0].descriptorCount, 1);
-    EXPECT_EQ(dsl_ci.pBindings[0].stageFlags, VK_SHADER_STAGE_COMPUTE_BIT);
-    EXPECT_EQ(dsl_ci.pBindings[0].pImmutableSamplers, nullptr);
-    EXPECT_EQ(dsl_ci.pBindings[1].binding, 1);
-    EXPECT_EQ(dsl_ci.pBindings[1].descriptorType, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
-    EXPECT_EQ((uintptr_t)dsl_ci.pBindings[1].pImmutableSamplers[0], 0);
-    EXPECT_EQ(dsl_ci.pBindings[1].descriptorCount, 1);
-    EXPECT_EQ(dsl_ci.pBindings[1].stageFlags, VK_SHADER_STAGE_FRAGMENT_BIT);
-    EXPECT_EQ(dsl_ci.pBindings[2].binding, 2);
-    EXPECT_EQ(dsl_ci.pBindings[2].descriptorType, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
-    EXPECT_EQ((uintptr_t)dsl_ci.pBindings[2].pImmutableSamplers[0], 1);
-    EXPECT_EQ(dsl_ci.pBindings[2].descriptorCount, 1);
-    EXPECT_EQ(dsl_ci.pBindings[2].stageFlags, VK_SHADER_STAGE_FRAGMENT_BIT);
-
-    EXPECT_EQ(data.graphicsPipelineState.immutableSamplerCount, 2);
-    EXPECT_STREQ(sampler_names[0], "ImmutableSampler1");
-    EXPECT_STREQ(sampler_names[1], "YcbcrSampler1");
-    EXPECT_EQ(sampler_cis[0].sType, VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO);
-    EXPECT_EQ(srm_ci.sType, VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO);
-    EXPECT_EQ(srm_ci.pNext, nullptr);
-    EXPECT_EQ(srm_ci.reductionMode, VK_SAMPLER_REDUCTION_MODE_MAX);
-    EXPECT_EQ(sampler_cis[0].addressModeU, VK_SAMPLER_ADDRESS_MODE_REPEAT);
-    EXPECT_EQ(sampler_cis[0].addressModeV, VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT);
-    EXPECT_EQ(sampler_cis[0].addressModeW, VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE);
-    EXPECT_EQ(sampler_cis[0].anisotropyEnable, VK_FALSE);
-    EXPECT_EQ(sampler_cis[0].borderColor, VK_BORDER_COLOR_FLOAT_CUSTOM_EXT);
-    EXPECT_EQ(sampler_cis[0].compareEnable, VK_FALSE);
-    EXPECT_EQ(sampler_cis[0].compareOp, VK_COMPARE_OP_NEVER);
-    EXPECT_EQ(sampler_cis[0].flags, 0);
-    EXPECT_EQ(sampler_cis[0].magFilter, VK_FILTER_CUBIC_EXT);
-    EXPECT_EQ(sampler_cis[0].maxAnisotropy, 2.0);
-    EXPECT_EQ(sampler_cis[0].maxLod, 1000.0);
-    EXPECT_EQ(sampler_cis[0].minFilter, VK_FILTER_NEAREST);
-    EXPECT_EQ(sampler_cis[0].minLod, 0.5);
-    EXPECT_EQ(sampler_cis[0].mipLodBias, 0.5);
-    EXPECT_EQ(sampler_cis[0].mipmapMode, VK_SAMPLER_MIPMAP_MODE_LINEAR);
-    EXPECT_EQ(sampler_cis[0].unnormalizedCoordinates, VK_TRUE);
-    EXPECT_EQ(sampler_cis[1].sType, VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO);
-    EXPECT_EQ(ycbcrci.sType, VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO);
-    EXPECT_EQ(ycbcrci.pNext, nullptr);
-    EXPECT_EQ((uintptr_t)ycbcrci.conversion, 0);
-    EXPECT_EQ(sampler_cis[1].addressModeU, VK_SAMPLER_ADDRESS_MODE_REPEAT);
-    EXPECT_EQ(sampler_cis[1].addressModeV, VK_SAMPLER_ADDRESS_MODE_REPEAT);
-    EXPECT_EQ(sampler_cis[1].addressModeW, VK_SAMPLER_ADDRESS_MODE_REPEAT);
-    EXPECT_EQ(sampler_cis[1].anisotropyEnable, VK_FALSE);
-    EXPECT_EQ(sampler_cis[1].borderColor, VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK);
-    EXPECT_EQ(sampler_cis[1].compareEnable, VK_FALSE);
-    EXPECT_EQ(sampler_cis[1].compareOp, VK_COMPARE_OP_NEVER);
-    EXPECT_EQ(sampler_cis[1].flags, 0);
-    EXPECT_EQ(sampler_cis[1].magFilter, VK_FILTER_NEAREST);
-    EXPECT_EQ(sampler_cis[1].maxAnisotropy, 0.0);
-    EXPECT_EQ(sampler_cis[1].maxLod, 0.0);
-    EXPECT_EQ(sampler_cis[1].minFilter, VK_FILTER_NEAREST);
-    EXPECT_EQ(sampler_cis[1].minLod, 0.0);
-    EXPECT_EQ(sampler_cis[1].mipLodBias, 0.0);
-    EXPECT_EQ(sampler_cis[1].mipmapMode, VK_SAMPLER_MIPMAP_MODE_NEAREST);
-    EXPECT_EQ(sampler_cis[1].unnormalizedCoordinates, VK_FALSE);
-
-    EXPECT_EQ(data.graphicsPipelineState.ycbcrSamplerCount, 1);
-    EXPECT_STREQ(ycbcr_names[0], "YcbcrConversion1");
-    EXPECT_EQ(ycbcr_ci.sType, VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO);
-#ifdef VK_USE_PLATFORM_SCREEN_QNX
-    EXPECT_EQ(ef_qnx.sType, VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_QNX);
-    EXPECT_EQ(ef_qnx.pNext, nullptr);
-    EXPECT_EQ(ef_qnx.externalFormat, 10);
-#else
-    EXPECT_EQ(ycbcr_ci.pNext, nullptr);
-#endif  // VK_USE_PLATFORM_SCREEN_QNX
-    EXPECT_EQ(ycbcr_ci.format, VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16);
-    EXPECT_EQ(ycbcr_ci.ycbcrModel, VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020);
-    EXPECT_EQ(ycbcr_ci.ycbcrRange, VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
-    EXPECT_EQ(ycbcr_ci.components.r, VK_COMPONENT_SWIZZLE_A);
-    EXPECT_EQ(ycbcr_ci.components.g, VK_COMPONENT_SWIZZLE_B);
-    EXPECT_EQ(ycbcr_ci.components.b, VK_COMPONENT_SWIZZLE_G);
-    EXPECT_EQ(ycbcr_ci.components.a, VK_COMPONENT_SWIZZLE_R);
-    EXPECT_EQ(ycbcr_ci.xChromaOffset, VK_CHROMA_LOCATION_COSITED_EVEN);
-    EXPECT_EQ(ycbcr_ci.yChromaOffset, VK_CHROMA_LOCATION_MIDPOINT);
-    EXPECT_EQ(ycbcr_ci.chromaFilter, VK_FILTER_CUBIC_EXT);
-    EXPECT_EQ(ycbcr_ci.forceExplicitReconstruction, VK_TRUE);
-
-    EXPECT_EQ(data.graphicsPipelineState.shaderFileNameCount, 2);
-    EXPECT_EQ(sfn[0].stage, VK_SHADER_STAGE_VERTEX_BIT);
-    EXPECT_STREQ(sfn[0].pFilename, "shader.vert.spv");
-    EXPECT_EQ(sfn[1].stage, VK_SHADER_STAGE_FRAGMENT_BIT);
-    EXPECT_STREQ(sfn[1].pFilename, "shader.frag.spv");
-
-    EXPECT_EQ(data.enabledExtensionCount, 1);
-    EXPECT_STREQ(data.ppEnabledExtensions[0], "VK_EXT_robustness2");
-
-    uint8_t expected_uuid[VK_UUID_SIZE] = {85, 43, 255, 24, 155, 64, 62, 24, 0, 0, 0, 0, 0, 0, 0, 0};
-    EXPECT_UUIDEQ(data.pipelineUUID, expected_uuid);
+    CompareData<VpjGraphicsPipelineState>(ref_data, data);
 }
 
 TEST_F(Parse, ObjectNameRemapping) {

--- a/tests/pcjson/pcjson_test_parse.cpp
+++ b/tests/pcjson/pcjson_test_parse.cpp
@@ -165,129 +165,123 @@ TEST_F(Parse, BasicTypesVkBool32) {
 TEST_F(Parse, VkPhysicalDeviceFeatures2) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex physical device features 2 JSON");
 
-    VkPhysicalDeviceFeatures2 pdf{};
-    auto [ref_pdf, json] = getVkPhysicalDeviceFeatures2(
-        0, std::make_tuple(getVkPhysicalDeviceVulkan11Features(), getVkPhysicalDeviceScalarBlockLayoutFeatures()));
+    for (auto seed : {0, 1, 2}) {
+        auto [ref_pdf, json_in] = getVkPhysicalDeviceFeatures2(seed);
 
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &pdf, &msg_));
-    CompareStruct(ref_pdf, pdf);
+        VkPhysicalDeviceFeatures2 res_pdf{};
+        CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json_in.c_str(), &res_pdf, &msg_));
+        CompareStruct(ref_pdf, res_pdf);
+    }
 }
 
 TEST_F(Parse, VkGraphicsPipelineCreateInfo) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex compute pipeline create info JSON");
 
-    VkGraphicsPipelineCreateInfo ci{};
-    auto [ref_ci, json] = getVkGraphicsPipelineCreateInfo(
-        0,
-        {getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_VERTEX_BIT),
-         getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT),
-         getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT,
-                                            std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo())),
-         getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_GEOMETRY_BIT),
-         getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_FRAGMENT_BIT)},
-        std::make_tuple(getVkPipelineDiscardRectangleStateCreateInfoEXT()));
+    for (auto seed : {0}) {
+        auto [ref_ci, json_in] = getVkGraphicsPipelineCreateInfo(seed);
 
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &ci, &msg_));
-    CompareStruct(ref_ci, ci);
+        VkGraphicsPipelineCreateInfo res_ci{};
+        CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json_in.c_str(), &res_ci, &msg_));
+        CompareStruct(ref_ci, res_ci);
+    }
 }
 
 TEST_F(Parse, VkComputePipelineCreateInfo) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex compute pipeline create info JSON");
 
-    VkComputePipelineCreateInfo ci{};
-    auto [ref_ci, json] = getVkComputePipelineCreateInfo(getVkPipelineShaderStageCreateInfo(
-        0, VK_SHADER_STAGE_COMPUTE_BIT, std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo())));
+    for (auto seed : {0, 1}) {
+        auto [ref_ci, json_in] = getVkComputePipelineCreateInfo(seed);
 
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &ci, &msg_));
-    CompareStruct(ref_ci, ci);
+        VkComputePipelineCreateInfo res_ci{};
+        CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json_in.c_str(), &res_ci, &msg_));
+        CompareStruct(ref_ci, res_ci);
+    }
 }
 
 TEST_F(Parse, VkSamplerYcbcrConversionCreateInfo) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex ycbcr conversion create info JSON");
 
-    VkSamplerYcbcrConversionCreateInfo ci{};
-    auto [ref_ci, json] = getVkSamplerYcbcrConversionCreateInfo();
+    for (auto seed : {0, 1, 2}) {
+        auto [ref_ci, json_in] = getVkSamplerYcbcrConversionCreateInfo(seed);
 
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &ci, &msg_));
-    CompareStruct(ref_ci, ci);
+        VkSamplerYcbcrConversionCreateInfo res_ci{};
+        CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json_in.c_str(), &res_ci, &msg_));
+        CompareStruct(ref_ci, res_ci);
+    }
 }
 
 TEST_F(Parse, VkSamplerCreateInfo) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex sampler create info JSON");
 
-    VkSamplerCreateInfo ci{};
-    auto [ref_ci, json] = getVkSamplerCreateInfo(
-        1,
-        std::make_tuple(getVkSamplerYcbcrConversionInfo(VkSamplerYcbcrConversion(12345)), getVkSamplerReductionModeCreateInfo(1)));
+    for (auto seed : {0, 1, 2}) {
+        for (auto param : std::vector<SamplerParams>{{}, {VkSamplerYcbcrConversion(12345)}}) {
+            auto [ref_ci, json_in] = getVkSamplerCreateInfo(seed, param);
 
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &ci, &msg_));
-    CompareStruct(ref_ci, ci);
+            VkSamplerCreateInfo res_ci{};
+            CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json_in.c_str(), &res_ci, &msg_));
+            CompareStruct(ref_ci, res_ci);
+        }
+    }
 }
 
 TEST_F(Parse, VkDescriptorSetLayoutCreateInfo) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex descriptor set layout create info JSON");
 
-    VkDescriptorSetLayoutCreateInfo ci{};
-    auto [ref_ci, json] = getVkDescriptorSetLayoutCreateInfo(0,
-                                                             {{1, VK_SHADER_STAGE_VERTEX_BIT},
-                                                              {1, VK_SHADER_STAGE_FRAGMENT_BIT, VkSampler(1)},
-                                                              {1, VK_SHADER_STAGE_FRAGMENT_BIT, VkSampler(2)}},
-                                                             std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
+    for (auto seed : {0, 1, 2, 3}) {
+        auto [ref_ci, json_in] = getVkDescriptorSetLayoutCreateInfo(seed);
 
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &ci, &msg_));
-    CompareStruct(ref_ci, ci);
+        VkDescriptorSetLayoutCreateInfo res_ci{};
+        CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json_in.c_str(), &res_ci, &msg_));
+        CompareStruct(ref_ci, res_ci);
+    }
 }
 
 TEST_F(Parse, VkPipelineLayoutCreateInfo) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex pipeline layout create info JSON");
 
-    VkPipelineLayoutCreateInfo ci;
-    auto [ref_ci, json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(12345)}});
+    for (auto seed : {0, 1, 2, 3}) {
+        auto [ref_ci, json_in] = getVkPipelineLayoutCreateInfo(seed);
 
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &ci, &msg_));
-    CompareStruct(ref_ci, ci);
+        VkPipelineLayoutCreateInfo res_ci{};
+        CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json_in.c_str(), &res_ci, &msg_));
+        CompareStruct(ref_ci, res_ci);
+    }
 }
 
 TEST_F(Parse, VkRenderPassCreateInfo) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex render pass create info JSON");
 
-    VkRenderPassCreateInfo ci;
-    auto [ref_ci, json] = getVkRenderPassCreateInfo(
-        0, std::make_tuple(getVkRenderPassInputAttachmentAspectCreateInfo(), getVkRenderPassMultiviewCreateInfo()));
+    for (auto seed : {0, 1, 2, 3}) {
+        auto [ref_ci, json_in] = getVkRenderPassCreateInfo(seed);
 
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &ci, &msg_));
-    CompareStruct(ref_ci, ci);
+        VkRenderPassCreateInfo res_ci{};
+        CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json_in.c_str(), &res_ci, &msg_));
+        CompareStruct(ref_ci, res_ci);
+    }
 }
 
 TEST_F(Parse, VkRenderPassCreateInfo2) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex render pass 2 layout create info JSON");
 
-    VkRenderPassCreateInfo2 ci;
-    auto [ref_ci, json] = getVkRenderPassCreateInfo2(0);
+    for (auto seed : {0, 1}) {
+        auto [ref_ci, json_in] = getVkRenderPassCreateInfo2(seed);
 
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &ci, &msg_));
-    CompareStruct(ref_ci, ci);
+        VkRenderPassCreateInfo2 res_ci{};
+        CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json_in.c_str(), &res_ci, &msg_));
+        CompareStruct(ref_ci, res_ci);
+    }
 }
 
 TEST_F(Parse, VkShaderModuleCreateInfo) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex shader module create info JSON");
 
-    VkShaderModuleCreateInfo sm_ci;
-    std::string json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO",
-        "pNext": "NULL",
-        "flags": 0,
-        "codeSize": 4,
-        "pCode": [25, 123, 42, 8]
-    })"};
+    for (auto seed : {0, 1}) {
+        auto [ref_ci, json_in] = getVkShaderModuleCreateInfo(seed);
 
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &sm_ci, &msg_));
-
-    EXPECT_EQ(sm_ci.sType, VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO);
-    EXPECT_EQ(sm_ci.pNext, nullptr);
-    EXPECT_EQ(sm_ci.flags, 0);
-    EXPECT_EQ(sm_ci.codeSize, 4);
-    EXPECT_EQ(sm_ci.pCode[0], (25 << 0) + (123 << 8) + (42 << 16) + (8 << 24));
+        VkShaderModuleCreateInfo res_ci{};
+        CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json_in.c_str(), &res_ci, &msg_));
+        CompareStruct(ref_ci, res_ci);
+    }
 }
 
 TEST_F(Parse, VkDeviceObjectReservationCreateInfo) {
@@ -415,54 +409,13 @@ TEST_F(Parse, VkDeviceObjectReservationCreateInfo) {
 TEST_F(Parse, VkPipelineOfflineCreateInfo) {
     TEST_DESCRIPTION("Tests parsing of a reasonably complex pipeline offline create info JSON");
 
-    VkPipelineOfflineCreateInfo po_ci;
-    std::string json = {R"({
-        "sType" : "VK_STRUCTURE_TYPE_PIPELINE_OFFLINE_CREATE_INFO",
-        "pNext": "NULL",
-        "pipelineIdentifier": [
-        85,
-        43,
-        255,
-        24,
-        155,
-        64,
-        62,
-        24,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0
-    ],
-        "matchControl": "VK_PIPELINE_MATCH_CONTROL_APPLICATION_UUID_EXACT_MATCH",
-        "poolEntrySize": 1048576
-    })"};
+    for (auto seed : {0}) {
+        auto [ref_ci, json_in] = getVkPipelineOfflineCreateInfo(seed);
 
-    CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json.c_str(), &po_ci, &msg_));
-
-    EXPECT_EQ(po_ci.sType, VK_STRUCTURE_TYPE_PIPELINE_OFFLINE_CREATE_INFO);
-    EXPECT_EQ(po_ci.pNext, nullptr);
-    EXPECT_EQ(po_ci.pipelineIdentifier[0], 85);
-    EXPECT_EQ(po_ci.pipelineIdentifier[1], 43);
-    EXPECT_EQ(po_ci.pipelineIdentifier[2], 255);
-    EXPECT_EQ(po_ci.pipelineIdentifier[3], 24);
-    EXPECT_EQ(po_ci.pipelineIdentifier[4], 155);
-    EXPECT_EQ(po_ci.pipelineIdentifier[5], 64);
-    EXPECT_EQ(po_ci.pipelineIdentifier[6], 62);
-    EXPECT_EQ(po_ci.pipelineIdentifier[7], 24);
-    EXPECT_EQ(po_ci.pipelineIdentifier[8], 0);
-    EXPECT_EQ(po_ci.pipelineIdentifier[9], 0);
-    EXPECT_EQ(po_ci.pipelineIdentifier[10], 0);
-    EXPECT_EQ(po_ci.pipelineIdentifier[11], 0);
-    EXPECT_EQ(po_ci.pipelineIdentifier[12], 0);
-    EXPECT_EQ(po_ci.pipelineIdentifier[13], 0);
-    EXPECT_EQ(po_ci.pipelineIdentifier[14], 0);
-    EXPECT_EQ(po_ci.pipelineIdentifier[15], 0);
-    EXPECT_EQ(po_ci.matchControl, VK_PIPELINE_MATCH_CONTROL_APPLICATION_UUID_EXACT_MATCH);
-    EXPECT_EQ(po_ci.poolEntrySize, 1048576);
+        VkPipelineOfflineCreateInfo res_ci{};
+        CHECK_PARSE(vpjParseSingleStructJson(this->parser_, json_in.c_str(), &res_ci, &msg_));
+        CompareStruct(ref_ci, res_ci);
+    }
 }
 
 TEST_F(Parse, ComputePipelineJSON) {
@@ -471,31 +424,22 @@ TEST_F(Parse, ComputePipelineJSON) {
     VpjData data{};
 
     const char* ycbcr_names[1] = {"YcbcrConversion1"};
-    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
-    auto ycbcr_conversion = VkSamplerYcbcrConversion(100);
+    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(0);
 
     const char* sampler_names[2] = {"ImmutableSampler1", "YcbcrSampler1"};
-    auto [immut_sampler_ci, immut_sampler_json] =
-        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerReductionModeCreateInfo(VK_SAMPLER_REDUCTION_MODE_MAX)));
-    auto [ycbcr_sampler_ci, ycbcr_sampler_json] =
-        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerYcbcrConversionInfo(ycbcr_conversion, ycbcr_names[0])));
+    auto [immut_sampler_ci, immut_sampler_json] = getVkSamplerCreateInfo(0);
+    auto [ycbcr_sampler_ci, ycbcr_sampler_json] = getVkSamplerCreateInfo(0, {VkSamplerYcbcrConversion(0), ycbcr_names[0]});
     VkSamplerCreateInfo sampler_ci[2] = {*immut_sampler_ci.ptr(), *ycbcr_sampler_ci.ptr()};
-    VkSampler immutableSamplers[2] = {VkSampler(100), VkSampler(101)};
 
     const char* dsl_names[1] = {"DescriptorSetLayout1"};
     auto [dsl_ci, dsl_json] =
-        getVkDescriptorSetLayoutCreateInfo(0,
-                                           {{1, VK_SHADER_STAGE_COMPUTE_BIT},
-                                            {1, VK_SHADER_STAGE_COMPUTE_BIT, immutableSamplers[0], sampler_names[0]},
-                                            {1, VK_SHADER_STAGE_COMPUTE_BIT, immutableSamplers[1], sampler_names[1]}},
-                                           std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
+        getVkDescriptorSetLayoutCreateInfo(0, {{VkSampler(0), sampler_names[0]}, {VkSampler(1), sampler_names[1]}});
 
-    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(100), dsl_names[0]}});
+    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(0), dsl_names[0]}});
 
-    auto [cp_ci, cp_json] = getVkComputePipelineCreateInfo(getVkPipelineShaderStageCreateInfo(
-        0, VK_SHADER_STAGE_COMPUTE_BIT, std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo())));
+    auto [cp_ci, cp_json] = getVkComputePipelineCreateInfo(0);
 
-    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0, std::make_tuple(getVkPhysicalDeviceSynchronization2Features()));
+    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0);
 
     auto [shaderFileNames, shaderFileNames_json] = getShaderFileNames({{VK_SHADER_STAGE_COMPUTE_BIT, "shader.comp.spv"}});
 
@@ -587,38 +531,29 @@ TEST_F(Parse, GraphicsPipelineJSON) {
     VpjData data{};
 
     const char* ycbcr_names[1] = {"YcbcrConversion1"};
-    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(VK_SAMPLER_YCBCR_RANGE_ITU_NARROW);
-    auto ycbcr_conversion = VkSamplerYcbcrConversion(0);
+    auto [ycbcr_ci, ycbcr_json] = getVkSamplerYcbcrConversionCreateInfo(1);
 
     const char* sampler_names[2] = {"ImmutableSampler1", "YcbcrSampler1"};
-    auto [immut_sampler_ci, immut_sampler_json] =
-        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerReductionModeCreateInfo(VK_SAMPLER_REDUCTION_MODE_MAX)));
-    auto [ycbcr_sampler_ci, ycbcr_sampler_json] =
-        getVkSamplerCreateInfo(0, std::make_tuple(getVkSamplerYcbcrConversionInfo(ycbcr_conversion, ycbcr_names[0])));
+    auto [immut_sampler_ci, immut_sampler_json] = getVkSamplerCreateInfo(1);
+    auto [ycbcr_sampler_ci, ycbcr_sampler_json] = getVkSamplerCreateInfo(1, {VkSamplerYcbcrConversion(0), ycbcr_names[0]});
     VkSamplerCreateInfo sampler_ci[2] = {*immut_sampler_ci.ptr(), *ycbcr_sampler_ci.ptr()};
-    VkSampler immutableSamplers[2] = {VkSampler(0), VkSampler(1)};
 
     const char* dsl_names[1] = {"DescriptorSetLayout1"};
     auto [dsl_ci, dsl_json] =
-        getVkDescriptorSetLayoutCreateInfo(0,
-                                           {{1, VK_SHADER_STAGE_VERTEX_BIT},
-                                            {1, VK_SHADER_STAGE_FRAGMENT_BIT, immutableSamplers[0], sampler_names[0]},
-                                            {1, VK_SHADER_STAGE_FRAGMENT_BIT, immutableSamplers[1], sampler_names[1]}},
-                                           std::make_tuple(getVkDescriptorSetLayoutBindingFlagsCreateInfo(0, 3)));
+        getVkDescriptorSetLayoutCreateInfo(1, {{VkSampler(0), sampler_names[0]}, {VkSampler(1), sampler_names[1]}});
 
-    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(0, {{VkDescriptorSetLayout(0), dsl_names[0]}});
+    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(1, {{VkDescriptorSetLayout(0), dsl_names[0]}});
 
-    auto [renderPass, renderPass_json] = getVkRenderPassCreateInfo(0);
+    auto [renderPass, renderPass_json] = getVkRenderPassCreateInfo(1);
 
-    auto [gp_ci, gp_json] = getVkGraphicsPipelineCreateInfo(
-        0, {getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_VERTEX_BIT),
-            getVkPipelineShaderStageCreateInfo(0, VK_SHADER_STAGE_FRAGMENT_BIT,
-                                               std::make_tuple(getVkPipelineShaderStageRequiredSubgroupSizeCreateInfo()))});
+    auto [gp_ci, gp_json] = getVkGraphicsPipelineCreateInfo(1);
 
-    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(0, std::make_tuple(getVkPhysicalDeviceSynchronization2Features()));
+    auto [pdf, pdf_json] = getVkPhysicalDeviceFeatures2(1);
 
     auto [shaderFileNames, shaderFileNames_json] = getShaderFileNames({
         {VK_SHADER_STAGE_VERTEX_BIT, "shader.vert.spv"},
+        {VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, "shader.tess_ctrl.spv"},
+        {VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, "shader.tess_eval.spv"},
         {VK_SHADER_STAGE_FRAGMENT_BIT, "shader.frag.spv"},
     });
 


### PR DESCRIPTION
This PR moves the PCJSON generator/parser testing over to a new set of struct/json generator utilities. The goal is to deduplicate the current set of highly repetitive tests and make adding newer tests more safe and terse.

**Applies on top of #33**

## Notes for the reviewer

- The bulk of the new functionality is in `json_struct_helpers.h`. There are two sets of new functions used in testing:
  - `getVkSomeCreateInfo(int seed, ...)` creates some Vulkan structure and the corresponding JSON snippet where `...` are customization points, either important handles or a pNext-chain to chain onto the structure.
  - `CompareStruct(vku::safe_VkSomeStruct& ref, VkSomeStruct& res)` is the parser equivalent of `CompareJson()` used in generator tests.
- The idea is that minimally whatever tests we have in generator testing, we should also be able to parse. (Some corner cases may be specific to either one or the other type of testing.)
  - In one test, one element of the resulting pair is the input while the other is the reference, and vice versa in the other test. A typical pair of generator/parser tests looks like the following:
  ```c++
  auto [input_ci, ref_json] = getVkSamplerYcbcrConversionCreateInfo();

  const char* result_json = nullptr;
  EXPECT_TRUE(vpjGenerateSingleStructJson(generator_, &input_ci, &result_json, &msg_));
  CHECK_GEN();
  EXPECT_TRUE(CompareJson(result_json, ref_json));
  ```

  ```c++
  auto [ref_ci, input_json] = getVkSamplerYcbcrConversionCreateInfo();

  VkSamplerYcbcrConversionCreateInfo result_ci{};
  CHECK_PARSE(vpjParseSingleStructJson(this->parser_, input_json.c_str(), &result_ci, &msg_));
  CompareStruct(ref_ci, result_ci);
  ```
- pNext customization doesn't appear in all `getVkSomeCreateInfo` interfaces. If there is no functionality one would like to customize in a test, they can be internalized completely, for eg. `getVkSubpassDescription2` only chains onto pNext in one of the `seed` cases.
- `CompareStruct` is a semantically-aware `operator==` for Vulkan structures. There is one tricky, pcutil-specific aspect to these checks: when parsing JSONs with handle renaming, the rewritable handles no longer compare equal, because they turn into indices in the result `VpjData`. The current API skips checking these values in the renamed cases. This done because there are dedicated tests for checking object renaming.

### Other fixes

- The generator no longer turns unnamed handles into empty arrays.
- The generator now properly shortens multibit flag bits even when mixed with singlebit flag bits, eg. `VK_SHADER_STAGE_ALL_GRAPHICS | VK_SHADER_STAGE_COMPUTE_BIT` serializes to `"VK_SHADER_STAGE_ALL_GRAPHICS | VK_SHADER_STAGE_COMPUTE_BIT"` and `ALL_GRAPHICS` doesn't dissociate into its constituents.