### PR TITLE
scripts: Update cxxopts dependency to v3.3.1

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -68,7 +68,7 @@
             "sub_dir": "cxxopts",
             "build_dir": "cxxopts/build",
             "install_dir": "cxxopts/build/install",
-            "commit": "v3.2.1",
+            "commit": "v3.3.1",
             "cmake_options": [
                 "-DCXXOPTS_BUILD_EXAMPLES=OFF",
                 "-DCXXOPTS_BUILD_TESTS=OFF",


### PR DESCRIPTION
The newer version seems to work and contains the cstdint fix.