### PR TITLE
docs: fix pipeline_cache_device_flag typo in PccDiscovery.md

### DIFF
--- a/docs/PccDiscovery.md
+++ b/docs/PccDiscovery.md
@@ -33,7 +33,7 @@ Here is an example PCC manifest file:
     "devices": [
         {
             "pipeline_cache_compiler": "<path-to-pcc-executable>",
-            "pipeline_cache_device_flags": "<command-line-flag-taking-a-device-id-argument>",
+            "pipeline_cache_device_flag": "<command-line-flag-taking-a-device-id-argument>",
             "pipeline_cache_debug_flag": "<command-line-flag-enabling-debug-info>",
             "vendor_id_filter" : "<optional-vendor-id-filter>",
             "driver_id_filter" : "<optional-driver-id-filter>",


### PR DESCRIPTION
The JSON schema example in the `devices` block used `pipeline_cache_device_flags` (plural) while the property table on the same page correctly defines the property as `pipeline_cache_device_flag` (singular). This inconsistency causes confusion when implementing a PCC manifest: the example and the normative table disagree.

The singular form `pipeline_cache_device_flag` is correct and matches the `VulkanSCPccDiscovery` CMake module implementation which reads this property by name.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)