### PR TITLE
parser: Accept legacy bare-integer flag masks

### DIFF
--- a/library/pcjson/generated/vksc_pipeline_json_parse.hpp
+++ b/library/pcjson/generated/vksc_pipeline_json_parse.hpp
@@ -4396,6 +4396,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkPipelineCreateFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkPipelineCreateFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4417,6 +4421,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkPipelineShaderStageCreateFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkPipelineShaderStageCreateFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4477,6 +4485,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkCullModeFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkCullModeFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4538,6 +4550,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkColorComponentFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkColorComponentFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4566,6 +4582,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkPipelineCreateFlagBits2_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkPipelineCreateFlags2>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4587,6 +4607,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkPipelineCreationFeedbackFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkPipelineCreationFeedbackFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4616,6 +4640,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkSamplerCreateFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkSamplerCreateFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4637,6 +4665,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkDescriptorSetLayoutCreateFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkDescriptorSetLayoutCreateFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4658,6 +4690,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkShaderStageFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkShaderStageFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4679,6 +4715,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkDescriptorBindingFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkDescriptorBindingFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4700,6 +4740,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkPipelineLayoutCreateFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkPipelineLayoutCreateFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4721,6 +4765,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkRenderPassCreateFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkRenderPassCreateFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4742,6 +4790,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkAttachmentDescriptionFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkAttachmentDescriptionFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4763,6 +4815,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkSubpassDescriptionFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkSubpassDescriptionFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4784,6 +4840,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkPipelineStageFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkPipelineStageFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4805,6 +4865,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkAccessFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkAccessFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4826,6 +4890,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkDependencyFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkDependencyFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4847,6 +4915,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkImageAspectFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkImageAspectFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4868,6 +4940,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkPipelineStageFlagBits2_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkPipelineStageFlags2>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4889,6 +4965,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkAccessFlagBits2_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkAccessFlags2>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4910,6 +4990,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkPipelineCacheCreateFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkPipelineCacheCreateFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4931,6 +5015,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkBufferCreateFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkBufferCreateFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4952,6 +5040,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkBufferUsageFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkBufferUsageFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4973,6 +5065,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkBufferUsageFlagBits2_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkBufferUsageFlags2>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -4994,6 +5090,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkExternalMemoryHandleTypeFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkExternalMemoryHandleTypeFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -5015,6 +5115,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkImageCreateFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkImageCreateFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }
@@ -5036,6 +5140,10 @@ class ParserBase : protected Base {
                 str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                 result |= parse_VkImageUsageFlagBits_c_str(str.c_str());
             }
+        } else if (accept_integers_as_strings_ && json.isUInt64()) {
+            // Legacy input: older CTS generators emit non-zero flag masks as bare
+            // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+            result = static_cast<VkImageUsageFlags>(json.asUInt64());
         } else {
             Error() << "Invalid format";
         }

--- a/library/pcjson/vksc_pipeline_json_parse.cpp
+++ b/library/pcjson/vksc_pipeline_json_parse.cpp
@@ -500,7 +500,11 @@ class Parser : private ParserBase {
 
         // Issue #3
         // The legacy generator will generate some integer values as strings containing the numbers.
-        // This is handled by enabling relaxed integer parsing, accepting strings containing numbers.
+        // It also serializes 64-bit synchronization2 flag masks (VkPipelineStageFlags2 / VkAccessFlags2,
+        // e.g. on a VkMemoryBarrier2) as bare integers instead of "|"-joined bit-name strings, even
+        // though the schema permits only integer 0 for a flags field. Both are handled by enabling
+        // relaxed integer parsing, which accepts strings containing numbers as well as a bare non-zero
+        // integer mask for a flags field.
         SetAcceptIntegersAsStrings(true);
     }
 

--- a/scripts/generators/json_parse_generator.py
+++ b/scripts/generators/json_parse_generator.py
@@ -545,6 +545,10 @@ class JsonParseGenerator(BaseGenerator):
                             str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
                             result |= parse_{flags.bitmaskName}_c_str(str.c_str());
                         }}
+                    }} else if (accept_integers_as_strings_ && json.isUInt64()) {{
+                        // Legacy input: older CTS generators emit non-zero flag masks as bare
+                        // integers (the schema allows only 0). Accept the raw mask in relaxed mode.
+                        result = static_cast<{flags.name}>(json.asUInt64());
                     }} else {{
                         Error() << "Invalid format";
                     }}

--- a/tests/pcjson/pcjson_test_parse.cpp
+++ b/tests/pcjson/pcjson_test_parse.cpp
@@ -1724,3 +1724,126 @@ TEST_F(Parse, AcceptLegacyInvalidInputData) {
     EXPECT_EQ(po_ci->sType, VK_STRUCTURE_TYPE_PIPELINE_OFFLINE_CREATE_INFO);
     EXPECT_EQ(po_ci->poolEntrySize, 42);
 }
+
+TEST_F(Parse, AcceptLegacyBareNumberFlags2) {
+    TEST_DESCRIPTION(
+        "The legacy (Vulkan-Docs) generator used by older VulkanSC-CTS serializes 64-bit "
+        "synchronization2 flag masks (a VkMemoryBarrier2's VkPipelineStageFlags2 / VkAccessFlags2 "
+        "in a VkSubpassDependency2 pNext) as bare JSON integers rather than \"|\"-joined bit-name "
+        "strings. The schema permits an integer only when it is 0, so strict parsing rejects a "
+        "non-zero raw mask; relaxed/legacy parsing accepts it as the raw mask value.");
+
+    // The relaxed/legacy flag only affects vpjParsePipelineJson (per the public API contract), so the
+    // renderpass2 is embedded in an otherwise-strictly-valid graphics pipeline built from the same
+    // helpers as the GraphicsPipelineJSON test. The only schema violation is the bare-number sync2
+    // masks on the VkMemoryBarrier2 in the subpass dependency's pNext; every other 32-bit flags field
+    // uses a bare 0, which the schema (and strict parsing) permit.
+    VpjData data{};
+
+    auto [pl_ci, pl_json] = getVkPipelineLayoutCreateInfo(1);
+    auto [gp_ci, gp_json] = getVkGraphicsPipelineCreateInfo(1);
+    auto [shaderFileNames, shaderFileNames_json] = getShaderFileNames({
+        {VK_SHADER_STAGE_VERTEX_BIT, "shader.vert.spv"},
+        {VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, "shader.tess_ctrl.spv"},
+        {VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, "shader.tess_eval.spv"},
+        {VK_SHADER_STAGE_FRAGMENT_BIT, "shader.frag.spv"},
+    });
+
+    // The mask values are arbitrary representative synchronization2 bit combinations (e.g.
+    // 1024 = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, 256 = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT);
+    // the exact bits are irrelevant - the test only verifies the raw 64-bit values round-trip unchanged,
+    // since relaxed parsing accepts the bare mask without decomposing or validating individual bits.
+    const std::string renderpass2_json = R"({
+                "sType" : "VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2",
+                "pNext" : "NULL",
+                "flags" : 0,
+                "attachmentCount" : 0,
+                "pAttachments" : "NULL",
+                "subpassCount" : 1,
+                "pSubpasses" :
+                [
+                    {
+                        "sType" : "VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2",
+                        "pNext" : "NULL",
+                        "flags" : 0,
+                        "pipelineBindPoint" : "VK_PIPELINE_BIND_POINT_GRAPHICS",
+                        "viewMask" : 0,
+                        "inputAttachmentCount" : 0,
+                        "pInputAttachments" : "NULL",
+                        "colorAttachmentCount" : 0,
+                        "pColorAttachments" : "NULL",
+                        "pResolveAttachments" : "NULL",
+                        "pDepthStencilAttachment" : "NULL",
+                        "preserveAttachmentCount" : 0,
+                        "pPreserveAttachments" : "NULL"
+                    }
+                ],
+                "dependencyCount" : 1,
+                "pDependencies" :
+                [
+                    {
+                        "sType" : "VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2",
+                        "pNext" :
+                        {
+                            "sType" : "VK_STRUCTURE_TYPE_MEMORY_BARRIER_2",
+                            "pNext" : "NULL",
+                            "srcStageMask" : 1024,
+                            "srcAccessMask" : 256,
+                            "dstStageMask" : 1152,
+                            "dstAccessMask" : 352
+                        },
+                        "srcSubpass" : 4294967295,
+                        "dstSubpass" : 0,
+                        "srcStageMask" : 0,
+                        "dstStageMask" : 0,
+                        "srcAccessMask" : 0,
+                        "dstAccessMask" : 0,
+                        "dependencyFlags" : 0,
+                        "viewOffset" : 0
+                    }
+                ],
+                "correlatedViewMaskCount" : 0,
+                "pCorrelatedViewMasks" : "NULL"
+    })";
+
+    const std::string json = R"({
+        "GraphicsPipelineState" :
+        {
+            "Renderpass2" : )" +
+                             renderpass2_json + R"(,
+            "GraphicsPipeline" : )" +
+                             gp_json + R"(,
+            "PipelineLayout" : )" +
+                             pl_json + R"(,
+            "ShaderFileNames" : )" +
+                             shaderFileNames_json + R"(
+        },
+        "PipelineUUID" : [85, 43, 255, 24, 155, 64, 62, 24, 0, 0, 0, 0, 0, 0, 0, 0]
+    })";
+
+    // Strict parsing (default parser, no legacy flag): the bare non-zero sync2 masks are a schema
+    // violation and the whole pipeline parse is rejected.
+    {
+        VpjParser strict = vpjCreateParser();
+        VpjData strict_data{};
+        const char* msg = nullptr;
+        EXPECT_FALSE(vpjParsePipelineJson(strict, json.c_str(), &strict_data, &msg));
+        vpjDestroyParser(strict);
+    }
+
+    // Relaxed/legacy parsing: the bare integers are accepted as the raw 64-bit mask values.
+    vpjSetAcceptLegacyInvalidInputData(this->parser_, true);
+    EXPECT_TRUE(vpjParsePipelineJson(this->parser_, json.c_str(), &data, &msg_));
+    CHECK_PARSE(true);
+
+    auto rp = reinterpret_cast<const VkRenderPassCreateInfo2*>(data.graphicsPipelineState.pRenderPass);
+    ASSERT_NE(rp, nullptr);
+    ASSERT_EQ(rp->dependencyCount, 1u);
+    auto barrier = reinterpret_cast<const VkMemoryBarrier2*>(rp->pDependencies[0].pNext);
+    ASSERT_NE(barrier, nullptr);
+    EXPECT_EQ(barrier->sType, VK_STRUCTURE_TYPE_MEMORY_BARRIER_2);
+    EXPECT_EQ(barrier->srcStageMask, 1024u);
+    EXPECT_EQ(barrier->srcAccessMask, 256u);
+    EXPECT_EQ(barrier->dstStageMask, 1152u);
+    EXPECT_EQ(barrier->dstAccessMask, 352u);
+}


### PR DESCRIPTION
## Problem

The pipeline JSON generator used by older VulkanSC-CTS (<= 1.0.2.1) serializes
64-bit synchronization2 flag masks — a `VkMemoryBarrier2`'s `VkPipelineStageFlags2` /
`VkAccessFlags2`, for example in a `VkSubpassDependency2` `pNext` — as bare JSON
integers (`"srcStageMask": 1024`) rather than `"|"`-joined bit-name strings. The
generated flags parser rejects any bare non-zero integer with
`Error() << "Invalid format"`, so such legacy pipeline JSON fails to parse.

## Change

Accept a bare non-zero integer as the raw mask value, but only when relaxed
parsing is enabled via `vpjSetAcceptLegacyInvalidInputData` (which turns on
accept-integers-as-strings). Strict parsing still rejects it as a schema
violation, since the schema permits only integer `0` for a flags field. The
relaxed branch is added to the `genFlagsMethod` codegen template, so the
regenerated `vksc_pipeline_json_parse.hpp` picks it up across every bitmask
flags parser.

## Test

`Parse.AcceptLegacyBareNumberFlags2` parses an otherwise-valid pipeline whose
`VkSubpassDependency2` carries a `VkMemoryBarrier2` with bare-integer sync2
masks, through `vpjParsePipelineJson`. Strict parsing (default) rejects it;
relaxed parsing accepts it with the correct raw mask values.

---
**GenAI disclosure:** Implementation, test authoring, and pull-request drafting assisted by Claude (claude-opus-4-8, Anthropic, commercial SaaS — Claude Code CLI).
